### PR TITLE
Animate popups scaling from center

### DIFF
--- a/script.js
+++ b/script.js
@@ -38,6 +38,13 @@ zones.forEach(zone => {
   `;
   popupsContainer.appendChild(popup);
   popups[zone.id] = popup; // guardar referencia
+
+  // Asegurar que las ventanas se oculten tras la animación de cierre
+  popup.addEventListener('transitionend', () => {
+    if (!popup.classList.contains('visible')) {
+      popup.classList.add('hidden');
+    }
+  });
 });
 
 // Abrir ventana al hacer click en una zona
@@ -54,12 +61,18 @@ popupsContainer.addEventListener('click', e => {
 });
 
 function openPopup(id) {
-  Object.values(popups).forEach(p => p.classList.add('hidden'));
-  if (popups[id]) popups[id].classList.remove('hidden');
+  Object.entries(popups).forEach(([key, p]) => {
+    if (key === id) {
+      p.classList.remove('hidden');
+      requestAnimationFrame(() => p.classList.add('visible'));
+    } else {
+      p.classList.remove('visible');
+    }
+  });
 }
 
 function closePopup(id) {
-  if (popups[id]) popups[id].classList.add('hidden');
+  if (popups[id]) popups[id].classList.remove('visible');
 }
 
 // =============================

--- a/style.css
+++ b/style.css
@@ -78,7 +78,7 @@ body.light-mode {
   position: fixed;
   top: 50%;
   left: 50%;
-  transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%) scale(0);
   width: 90vw;
   height: 90vh;
   background: #ccc;
@@ -91,10 +91,19 @@ body.light-mode {
   font-size: 14px;
   font-family: 'PixelFont', monospace;
   overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+  transition: transform 0.3s ease, opacity 0.3s ease;
 }
 
 .popup.hidden {
   display: none;
+}
+
+.popup.visible {
+  transform: translate(-50%, -50%) scale(1);
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .popup-header {


### PR DESCRIPTION
## Summary
- add scale and opacity transition to popup windows and toggle via `.visible`
- adjust JavaScript to manage popup visibility with animated open/close behavior

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e589b92f0832ba341c420fa9e31f3