### PR TITLE
Add contact popup with social icons and pixel art form

### DIFF
--- a/config.js
+++ b/config.js
@@ -24,7 +24,41 @@ export const zones = [
     id: 'contacto',
     img: 'assets/casa.png',
     position: { bottom: '5vh', left: '5vw' },
-    popup: { title: 'Contacto', content: '' }
+    popup: {
+      title: 'Contacto',
+      content: `
+        <div class="contact-popup">
+          <div class="social-column">
+            <a href="https://twitter.com/" target="_blank">
+              <img src="https://cdn-icons-png.flaticon.com/512/733/733579.png" alt="Twitter" style="width:48px;height:48px;margin:4px;" />
+            </a>
+            <a href="https://instagram.com/" target="_blank">
+              <img src="https://cdn-icons-png.flaticon.com/512/2111/2111463.png" alt="Instagram" style="width:48px;height:48px;margin:4px;" />
+            </a>
+          </div>
+          <div class="form-column">
+            <form id="contact-form" action="https://formspree.io/f/YOUR_FORM_ID" method="POST">
+              <label>
+                Nombre<br />
+                <input type="text" name="name" required />
+              </label>
+              <br />
+              <label>
+                Email<br />
+                <input type="email" name="_replyto" required />
+              </label>
+              <br />
+              <label>
+                Mensaje<br />
+                <textarea name="message" rows="4" required></textarea>
+              </label>
+              <br />
+              <button type="submit">Enviar</button>
+            </form>
+          </div>
+        </div>
+      `
+    }
   },
   {
     id: 'plugins',

--- a/style.css
+++ b/style.css
@@ -144,3 +144,55 @@ body.light-mode {
   font-size: 16px;
   cursor: pointer;
 }
+
+/* Contact popup layout */
+.contact-popup {
+  display: flex;
+  gap: 20px;
+  height: 100%;
+}
+
+.social-column {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.social-column img {
+  image-rendering: pixelated;
+  cursor: pointer;
+}
+
+.form-column {
+  flex: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#contact-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-family: 'PixelFont', monospace;
+}
+
+#contact-form input,
+#contact-form textarea {
+  background: #fff;
+  color: #000;
+  border: 2px solid #000;
+  border-radius: 0;
+  padding: 4px;
+  font-family: inherit;
+}
+
+#contact-form button {
+  background: #000;
+  color: #fff;
+  border: 2px solid #000;
+  padding: 4px;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- add two-column contact popup with social icons and simple contact form
- style popup using pixel art aesthetics and flexible layout

## Testing
- `npm test` (fails: could not find package.json)


------
https://chatgpt.com/codex/tasks/task_e_688e7127974c832b93ad00dfd71dc720