### PR TITLE
Add central divider to contact popup

### DIFF
--- a/style.css
+++ b/style.css
@@ -150,6 +150,7 @@ body.light-mode {
   display: flex;
   gap: 20px;
   height: 100%;
+  align-items: stretch;
 }
 
 .social-column {
@@ -158,6 +159,8 @@ body.light-mode {
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  border-right: 2px solid #000;
+  padding-right: 20px;
 }
 
 .social-column img {


### PR DESCRIPTION
## Summary
- add a black divider in the contact popup social column
- ensure columns stretch to full height for consistent layout

## Testing
- `npm test` *(fails: could not find a package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e7a7cd568832bbf9939172fe98456