### PR TITLE
Cleanup contact form layout and styling

### DIFF
--- a/config.js
+++ b/config.js
@@ -39,20 +39,17 @@ export const zones = [
           <div class="form-column">
             <form id="contact-form" action="https://formspree.io/f/YOUR_FORM_ID" method="POST">
               <label>
-                Nombre<br />
+                Nombre
                 <input type="text" name="name" required />
               </label>
-              <br />
               <label>
-                Email<br />
+                Email
                 <input type="email" name="_replyto" required />
               </label>
-              <br />
               <label>
-                Mensaje<br />
+                Mensaje
                 <textarea name="message" rows="4" required></textarea>
               </label>
-              <br />
               <button type="submit">Enviar</button>
             </form>
           </div>

--- a/style.css
+++ b/style.css
@@ -180,6 +180,13 @@ body.light-mode {
   flex-direction: column;
   gap: 8px;
   font-family: 'PixelFont', monospace;
+  margin: 0 auto;
+}
+
+#contact-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
 #contact-form input,


### PR DESCRIPTION
## Summary
- Remove `<br />` tags from contact form labels for cleaner markup
- Style contact form labels with flex column layout and gap
- Center the contact form using `margin: 0 auto`

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e7ee71044832b9e81c9aad41f45b0