### PR TITLE
Equal column widths and resize divider on contact popup

### DIFF
--- a/style.css
+++ b/style.css
@@ -147,10 +147,22 @@ body.light-mode {
 
 /* Contact popup layout */
 .contact-popup {
+  position: relative;
   display: flex;
   gap: 20px;
   height: 100%;
   align-items: stretch;
+}
+
+.contact-popup::before {
+  content: "";
+  position: absolute;
+  top: 10%;
+  bottom: 10%;
+  left: 50%;
+  width: 4px;
+  background-color: #000;
+  transform: translateX(-50%);
 }
 
 .social-column {
@@ -159,8 +171,6 @@ body.light-mode {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  border-right: 2px solid #000;
-  padding-right: 20px;
 }
 
 .social-column img {
@@ -169,7 +179,7 @@ body.light-mode {
 }
 
 .form-column {
-  flex: 2;
+  flex: 1;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- Make contact popup columns equal width
- Replace border with centered pseudo-element divider that's thicker and shorter

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e90045554832b803455291ae15db0