### PR TITLE
Add dynamic instrumentals audio list with play/pause controls

### DIFF
--- a/config.js
+++ b/config.js
@@ -6,6 +6,10 @@ export const backgrounds = {
   light: 'assets/fondo.png'
 };
 
+// Lista de instrumentales disponibles
+// Añade más objetos { name: 'Título', src: 'assets/tu-archivo.mp3' }
+export const instrumentals = [];
+
 // Definición de zonas interactivas y su contenido emergente
 export const zones = [
   {

--- a/script.js
+++ b/script.js
@@ -1,7 +1,7 @@
 // --- script.js ---
 // Código estructurado para que sea fácil cambiar imágenes y contenido.
 
-import { backgrounds, zones } from './config.js';
+import { backgrounds, zones, instrumentals } from './config.js';
 
 // Referencias principales al DOM
 const gameArea = document.getElementById('game-area');
@@ -47,6 +47,9 @@ zones.forEach(zone => {
   });
 });
 
+// Crear listado de instrumentales
+populateInstrumentals();
+
 // Abrir ventana al hacer click en una zona
 zonesContainer.addEventListener('click', e => {
   const target = e.target.closest('.interactive-zone');
@@ -82,6 +85,64 @@ function openPopup(id) {
  */
 function closePopup(id) {
   if (popups[id]) popups[id].classList.remove('visible');
+  if (id === 'instrumentales' && currentAudio) {
+    currentAudio.audio.pause();
+    currentAudio.audio.currentTime = 0;
+    currentAudio.button.textContent = '▶';
+    currentAudio = null;
+  }
+}
+
+// =============================
+//  Listado de instrumentales
+// =============================
+let currentAudio = null;
+
+function populateInstrumentals() {
+  const container = document.querySelector('#popup-instrumentales .popup-content');
+  if (!container) return;
+  instrumentals.forEach(inst => {
+    const item = document.createElement('div');
+    item.className = 'audio-item';
+
+    const title = document.createElement('span');
+    title.textContent = inst.name;
+
+    const btn = document.createElement('button');
+    btn.textContent = '▶';
+
+    const audio = new Audio(inst.src);
+
+    btn.addEventListener('click', () => {
+      if (currentAudio && currentAudio.audio !== audio) {
+        currentAudio.audio.pause();
+        currentAudio.audio.currentTime = 0;
+        currentAudio.button.textContent = '▶';
+      }
+
+      if (audio.paused) {
+        audio.play();
+        btn.textContent = '⏸';
+        currentAudio = { audio, button: btn };
+      } else {
+        audio.pause();
+        audio.currentTime = 0;
+        btn.textContent = '▶';
+        currentAudio = null;
+      }
+    });
+
+    audio.addEventListener('ended', () => {
+      btn.textContent = '▶';
+      if (currentAudio && currentAudio.audio === audio) {
+        currentAudio = null;
+      }
+    });
+
+    item.appendChild(title);
+    item.appendChild(btn);
+    container.appendChild(item);
+  });
 }
 
 // =============================

--- a/style.css
+++ b/style.css
@@ -245,3 +245,34 @@ body.light-mode {
   margin: 8px;
   text-align: center;
 }
+
+/* Listado de instrumentales */
+.audio-item {
+  width: 80%;
+  height: 40px;
+  margin: 8px auto;
+  background: #000;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 10px;
+  box-sizing: border-box;
+}
+
+.audio-item button {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 16px;
+}
+
+body.light-mode .audio-item {
+  background: #eee;
+  color: #000;
+}
+
+body.light-mode .audio-item button {
+  color: inherit;
+}


### PR DESCRIPTION
## Summary
- allow configuration of instrumentals tracks
- render instrumentals popup with play/pause toggle and exclusive playback
- style audio items to fill 80% width and 40px height

## Testing
- `node --check script.js`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f2a4f3bc8832ba6c783f50b886430