### PR TITLE
Remove dynamic font size controls and use CSS variables

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,30 +11,6 @@
   <!-- Botón para cambiar entre modo claro y oscuro -->
   <button id="toggle-theme"></button>
 
-  <!-- Controles para ajustar el tamaño de letra de cada elemento -->
-  <div id="font-size-controls">
-    <div class="font-size-control">
-      <label for="popup-font-size-slider">Texto popup:</label>
-      <input type="range" id="popup-font-size-slider" min="12" max="32" value="16">
-      <span id="popup-font-size-value">16</span>px
-    </div>
-    <div class="font-size-control">
-      <label for="popup-header-font-size-slider">Encabezado popup:</label>
-      <input type="range" id="popup-header-font-size-slider" min="12" max="32" value="16">
-      <span id="popup-header-font-size-value">16</span>px
-    </div>
-    <div class="font-size-control">
-      <label for="close-btn-font-size-slider">Botón cerrar:</label>
-      <input type="range" id="close-btn-font-size-slider" min="12" max="32" value="16">
-      <span id="close-btn-font-size-value">16</span>px
-    </div>
-    <div class="font-size-control">
-      <label for="audio-button-font-size-slider">Botones audio:</label>
-      <input type="range" id="audio-button-font-size-slider" min="12" max="32" value="15">
-      <span id="audio-button-font-size-value">15</span>px
-    </div>
-  </div>
-
   <!-- Área principal del "juego" con personaje y zonas -->
   <div id="game-area">
     <!-- Contenedor del sprite del personaje -->

--- a/script.js
+++ b/script.js
@@ -9,30 +9,6 @@ const character = document.getElementById('character');
 const toggleBtn = document.getElementById('toggle-theme');
 const zonesContainer = document.getElementById('zones-container');
 const popupsContainer = document.getElementById('popups-container');
-const rootElement = document.documentElement;
-
-// Vincula controles de tamaño de fuente individuales
-function bindFontSizeControl(sliderId, valueId, cssVar) {
-  const slider = document.getElementById(sliderId);
-  const value = document.getElementById(valueId);
-  if (!slider || !value) return;
-  const initial = parseInt(
-    getComputedStyle(rootElement).getPropertyValue(cssVar),
-    10
-  );
-  slider.value = initial;
-  value.textContent = initial;
-  slider.addEventListener('input', () => {
-    const val = slider.value;
-    rootElement.style.setProperty(cssVar, val + 'px');
-    value.textContent = val;
-  });
-}
-
-bindFontSizeControl('popup-font-size-slider', 'popup-font-size-value', '--popup-font-size');
-bindFontSizeControl('popup-header-font-size-slider', 'popup-header-font-size-value', '--popup-header-font-size');
-bindFontSizeControl('close-btn-font-size-slider', 'close-btn-font-size-value', '--close-btn-font-size');
-bindFontSizeControl('audio-button-font-size-slider', 'audio-button-font-size-value', '--audio-button-font-size');
 
 // Objeto que guardará las ventanas emergentes generadas
 const popups = {};

--- a/style.css
+++ b/style.css
@@ -9,8 +9,10 @@
 :root {
   --bg-dark: url('assets/fondo dark.png');
   --bg-light: url('assets/fondo.png');
+  --popup-font-size: 12px;
   --popup-header-font-size: 16px;
-  --popup-content-font-size: 12px;
+  --close-btn-font-size: 16px;
+  --audio-button-font-size: 15px;
 }
 
 /* Estilos base del cuerpo */
@@ -129,7 +131,6 @@ body.light-mode {
   height: 40px;
   border-bottom: 2px solid #000;
   font-size: var(--popup-header-font-size);
-  font-size: var(--popup-header-font-size);
   font-family: 'PixelFont', monospace;
 }
 
@@ -138,7 +139,6 @@ body.light-mode {
   height: calc(100% - 20px);
   overflow-y: auto;
   font-size: var(--popup-font-size);
-  font-size: var(--popup-content-font-size);
   font-family: 'PixelFont', monospace;
 }
 
@@ -147,7 +147,6 @@ body.light-mode {
   border: none;
   color: #fff;
   font-size: var(--close-btn-font-size);
-  font-size: var(--popup-header-font-size);
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary
- remove slider block for font-size adjustment from the page
- strip font size control logic from `script.js`
- define fixed font sizes via CSS variables in `style.css`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fab21ef94832b89b0dee04cf9ef6c