### PR TITLE
feat: add configurable floating images

### DIFF
--- a/config.js
+++ b/config.js
@@ -91,3 +91,27 @@ export const zones = [
   }
 ];
 
+// Imágenes adicionales con posiciones ajustables
+export const floatingImages = [
+  {
+    id: 'img1',
+    src: 'assets/moon.png',
+    style: { top: '20vh', left: '10vw', width: '60px', height: '60px' }
+  },
+  {
+    id: 'img2',
+    src: 'assets/sun.png',
+    style: { top: '20vh', right: '10vw', width: '60px', height: '60px' }
+  },
+  {
+    id: 'img3',
+    src: 'assets/casa.png',
+    style: { bottom: '20vh', left: '10vw', width: '60px', height: '60px' }
+  },
+  {
+    id: 'img4',
+    src: 'assets/Fuente.png',
+    style: { bottom: '20vh', right: '10vw', width: '60px', height: '60px' }
+  }
+];
+

--- a/script.js
+++ b/script.js
@@ -1,7 +1,7 @@
 // --- script.js ---
 // Código estructurado para que sea fácil cambiar imágenes y contenido.
 
-import { backgrounds, zones, instrumentals } from './config.js';
+import { backgrounds, zones, instrumentals, floatingImages } from './config.js';
 
 // Referencias principales al DOM
 const gameArea = document.getElementById('game-area');
@@ -12,6 +12,18 @@ const popupsContainer = document.getElementById('popups-container');
 
 // Objeto que guardará las ventanas emergentes generadas
 const popups = {};
+
+// =============================
+//  Imágenes posicionables
+// =============================
+floatingImages.forEach(imgData => {
+  const img = document.createElement('img');
+  img.src = imgData.src;
+  img.id = imgData.id;
+  img.className = 'floating-image';
+  Object.assign(img.style, imgData.style);
+  gameArea.appendChild(img);
+});
 
 // =============================
 //  Creación dinámica de zonas y popups

--- a/style.css
+++ b/style.css
@@ -75,6 +75,12 @@ body.light-mode {
   user-select: none;
 }
 
+/* Imágenes posicionables */
+.floating-image {
+  position: absolute;
+  user-select: none;
+}
+
 /* Obstáculo de prueba */
 .obstacle {
   position: fixed;


### PR DESCRIPTION
## Summary
- allow four extra images to be positioned via config
- render configurable floating images at runtime
- style floating images with absolute positioning

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899e81956f0832b93d029dc359311df