### PR TITLE
Add collision to building images

### DIFF
--- a/script.js
+++ b/script.js
@@ -32,7 +32,8 @@ zones.forEach(zone => {
   // Imagen clicable
   const img = document.createElement('img');
   img.src = zone.img;
-  img.className = 'interactive-zone';
+  // También actúa como obstáculo para bloquear el movimiento
+  img.classList.add('interactive-zone', 'obstacle');
   Object.assign(img.style, zone.position); // top/left/etc.
   img.dataset.popup = zone.id; // relacionar con ventana
   zonesContainer.appendChild(img);

--- a/style.css
+++ b/style.css
@@ -81,8 +81,11 @@ body.light-mode {
   user-select: none;
 }
 
-/* Obstáculo de prueba */
-.obstacle {
+/* Elementos que bloquean al personaje (sin estilos para no afectar su apariencia) */
+.obstacle {}
+
+/* Obstáculo central de prueba */
+#obstacle {
   position: fixed;
   top: 50%;
   left: 50%;


### PR DESCRIPTION
## Summary
- mark dynamically created building images as obstacles to block character movement
- decouple obstacle styling from collision logic to keep buildings clickable

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a25ddaa38832bb1089418d63ce2ca