### PR TITLE
feat: add mobile menu and responsive layout

### DIFF
--- a/config.js
+++ b/config.js
@@ -17,12 +17,14 @@ export const zones = [
   {
     id: 'instrumentales',
     img: 'assets/Edificio1.png',
+    listLabel: 'assets/instrumentales.png',
     position: { top: '3vh', left: '6vw' },
     popup: { title: 'Instrumentales', content: '' }
   },
   {
     id: 'trabajos',
     img: 'assets/Edificio4.png',
+    listLabel: 'assets/trabajos.png',
     position: { top: '3vh', right: '6vw' },
     // Duplica el bloque <a class="video-card">…</a> para añadir más videos
     popup: {
@@ -44,6 +46,7 @@ export const zones = [
   {
     id: 'contacto',
     img: 'assets/Edificio3.png',
+    listLabel: 'assets/contacto.png',
     position: { bottom: '13vh', left: '6vw' },
     popup: {
       title: 'Contacto',
@@ -81,6 +84,7 @@ export const zones = [
   {
     id: 'plugins',
     img: 'assets/EDIFICIO2.png',
+    listLabel: 'assets/plugins.png',
     position: { bottom: '12vh', right: '6vw' },
     popup: {
       title: 'Plugins',

--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
   <!-- Botón para cambiar entre modo claro y oscuro -->
   <button id="toggle-theme"></button>
 
+  <div id="mobile-menu"></div>
+
   <!-- Área principal del "juego" con personaje y zonas -->
   <div id="game-area">
     <!-- Contenedor del sprite del personaje -->

--- a/script.js
+++ b/script.js
@@ -9,6 +9,7 @@ const character = document.getElementById('character');
 const toggleBtn = document.getElementById('toggle-theme');
 const zonesContainer = document.getElementById('zones-container');
 const popupsContainer = document.getElementById('popups-container');
+const mobileMenu = document.getElementById('mobile-menu');
 
 // Objeto que guardará las ventanas emergentes generadas
 const popups = {};
@@ -59,6 +60,21 @@ zones.forEach(zone => {
   });
 });
 
+// Menú móvil generado dinámicamente
+zones.forEach(zone => {
+  const item = document.createElement('div');
+  item.className = 'mobile-item';
+  item.dataset.popup = zone.id;
+  const img = document.createElement('img');
+  img.src = zone.listLabel;
+  img.alt = zone.id;
+  item.appendChild(img);
+  const label = document.createElement('span');
+  label.textContent = zone.popup.title;
+  item.appendChild(label);
+  mobileMenu.appendChild(item);
+});
+
 // Crear listado de instrumentales
 populateInstrumentals();
 
@@ -73,6 +89,12 @@ popupsContainer.addEventListener('click', e => {
   if (e.target.matches('.close-btn')) {
     closePopup(e.target.dataset.close);
   }
+});
+
+// Abrir ventana al seleccionar un elemento del menú móvil
+mobileMenu.addEventListener('click', e => {
+  const target = e.target.closest('.mobile-item');
+  if (target) openPopup(target.dataset.popup);
 });
 
 /**

--- a/style.css
+++ b/style.css
@@ -319,3 +319,31 @@ body.light-mode .audio-item {
 body.light-mode .audio-item button {
   color: inherit;
 }
+
+#mobile-menu {
+  display: none;
+  padding: 20px;
+}
+
+.mobile-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+  cursor: pointer;
+}
+
+@media (max-width: 768px) {
+  #mobile-menu {
+    display: block;
+  }
+
+  #game-area {
+    display: none;
+  }
+
+  .popup {
+    width: 95vw;
+    height: 90vh;
+  }
+}


### PR DESCRIPTION
## Summary
- add mobile menu container and responsive styles for small screens
- include list labels for zones and generate mobile menu items dynamically
- hook mobile menu items to open popups

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ba01e6504832ba699125f681bdde6