### PR TITLE
Use existing assets for mobile menu labels

### DIFF
--- a/config.js
+++ b/config.js
@@ -17,14 +17,14 @@ export const zones = [
   {
     id: 'instrumentales',
     img: 'assets/Edificio1.png',
-    listLabel: 'assets/instrumentales.png',
+    listLabel: 'assets/text1.png',
     position: { top: '3vh', left: '6vw' },
     popup: { title: 'Instrumentales', content: '' }
   },
   {
     id: 'trabajos',
     img: 'assets/Edificio4.png',
-    listLabel: 'assets/trabajos.png',
+    listLabel: 'assets/text2.png',
     position: { top: '3vh', right: '6vw' },
     // Duplica el bloque <a class="video-card">…</a> para añadir más videos
     popup: {
@@ -46,7 +46,7 @@ export const zones = [
   {
     id: 'contacto',
     img: 'assets/Edificio3.png',
-    listLabel: 'assets/contacto.png',
+    listLabel: 'assets/text3.png',
     position: { bottom: '13vh', left: '6vw' },
     popup: {
       title: 'Contacto',
@@ -84,7 +84,7 @@ export const zones = [
   {
     id: 'plugins',
     img: 'assets/EDIFICIO2.png',
-    listLabel: 'assets/plugins.png',
+    listLabel: 'assets/text1.png',
     position: { bottom: '12vh', right: '6vw' },
     popup: {
       title: 'Plugins',

--- a/script.js
+++ b/script.js
@@ -65,13 +65,17 @@ zones.forEach(zone => {
   const item = document.createElement('div');
   item.className = 'mobile-item';
   item.dataset.popup = zone.id;
-  const img = document.createElement('img');
-  img.src = zone.listLabel;
-  img.alt = zone.id;
-  item.appendChild(img);
-  const label = document.createElement('span');
-  label.textContent = zone.popup.title;
-  item.appendChild(label);
+
+  const labelImg = document.createElement('img');
+  labelImg.src = zone.listLabel;
+  labelImg.className = 'label';
+  item.appendChild(labelImg);
+
+  const buildingImg = document.createElement('img');
+  buildingImg.src = zone.img;
+  buildingImg.className = 'building';
+  item.appendChild(buildingImg);
+
   mobileMenu.appendChild(item);
 });
 


### PR DESCRIPTION
## Summary
- Replace missing `listLabel` references in `config.js` with available `text` images
- Render both label and building images in mobile menu and drop text title

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ba76f2440832b91e817959db825d2