### PR TITLE
Ajustar escalado de imágenes del menú móvil

### DIFF
--- a/style.css
+++ b/style.css
@@ -333,6 +333,17 @@ body.light-mode .audio-item button {
   cursor: pointer;
 }
 
+#mobile-menu img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+.mobile-item .label,
+.mobile-item .building {
+  width: 40vw; /* Ajustar según el diseño deseado */
+}
+
 @media (max-width: 768px) {
   #mobile-menu {
     display: block;


### PR DESCRIPTION
## Summary
- Escalar imágenes del menú móvil y limitar el ancho de elementos de cada ítem

## Testing
- `npm test` *(falla: Could not read package.json)*
- `npx playwright --version` *(falla: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_689bac713e24832baf73ee275410f899