### PR TITLE
style: refine mobile item layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -327,9 +327,12 @@ body.light-mode .audio-item button {
 
 .mobile-item {
   display: flex;
+  justify-content: space-between;
   align-items: center;
-  gap: 10px;
-  margin-bottom: 10px;
+  background: #ddd;        /* color sólido */
+  border: 4px solid #000;  /* borde negro */
+  padding: 10px;
+  margin: 8px 0;
   cursor: pointer;
 }
 
@@ -339,9 +342,12 @@ body.light-mode .audio-item button {
   display: block;
 }
 
-.mobile-item .label,
+.mobile-item .label {
+  max-width: 45%;
+}
+
 .mobile-item .building {
-  width: 40vw; /* Ajustar según el diseño deseado */
+  max-width: 45%;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- style mobile menu items as rectangular blocks with spacing
- constrain label and building images to equal widths for balanced layout

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bb1fe5e14832b87788212b2bbe298