### PR TITLE
Align mobile menu labels and buildings

### DIFF
--- a/style.css
+++ b/style.css
@@ -343,11 +343,15 @@ body.light-mode .audio-item button {
 }
 
 .mobile-item .label {
-  max-width: 45%;
+  margin-right: auto;
+  text-align: left;
+  max-width: 50%;
 }
 
 .mobile-item .building {
-  max-width: 45%;
+  margin-left: auto;
+  text-align: right;
+  max-width: 50%;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- ensure mobile menu item uses flexbox with vertical centering
- add margins and text alignment to mobile menu labels and building names
- limit label and building width to avoid overflow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bba578848832b9b089a33a0b3de9c