### PR TITLE
Simplify mobile layout with solid menu tiles

### DIFF
--- a/script.js
+++ b/script.js
@@ -63,19 +63,9 @@ zones.forEach(zone => {
 // Menú móvil generado dinámicamente
 zones.forEach(zone => {
   const item = document.createElement('div');
-  item.className = 'mobile-item';
+  item.className = `mobile-item item-${zone.id}`;
   item.dataset.popup = zone.id;
-
-  const labelImg = document.createElement('img');
-  labelImg.src = zone.listLabel;
-  labelImg.className = 'label';
-  item.appendChild(labelImg);
-
-  const buildingImg = document.createElement('img');
-  buildingImg.src = zone.img;
-  buildingImg.className = 'building';
-  item.appendChild(buildingImg);
-
+  item.textContent = zone.popup.title;
   mobileMenu.appendChild(item);
 });
 

--- a/style.css
+++ b/style.css
@@ -322,41 +322,32 @@ body.light-mode .audio-item button {
 
 #mobile-menu {
   display: none;
-  padding: 20px;
 }
 
 .mobile-item {
+  width: 100%;
+  height: 22vh;
+  box-sizing: border-box;
+  border: 5px solid #000;
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  background: #ddd;        /* color sólido */
-  border: 4px solid #000;  /* borde negro */
-  padding: 10px;
-  margin: 8px 0;
+  justify-content: center;
+  font-size: 2rem;
+  font-weight: bold;
   cursor: pointer;
+  color: #000;
 }
 
-#mobile-menu img {
-  max-width: 100%;
-  height: auto;
-  display: block;
-}
-
-.mobile-item .label {
-  margin-right: auto;
-  text-align: left;
-  max-width: 50%;
-}
-
-.mobile-item .building {
-  margin-left: auto;
-  text-align: right;
-  max-width: 50%;
-}
+.item-instrumentales { background: #f4a261; }
+.item-trabajos       { background: #2a9d8f; }
+.item-contacto       { background: #e9c46a; }
+.item-plugins        { background: #e76f51; }
 
 @media (max-width: 768px) {
   #mobile-menu {
-    display: block;
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
   }
 
   #game-area {


### PR DESCRIPTION
## Summary
- Replace mobile menu items with four full-width tiles linking to Instrumentales, Trabajos, Contacto, and Plugins.
- Style mobile view with 22vh colored rectangles and remove extra mobile styling.

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bcb0a06cc832b812c49e0bad81fb4