### PR TITLE
feat: add images to mobile menu

### DIFF
--- a/script.js
+++ b/script.js
@@ -65,7 +65,16 @@ zones.forEach(zone => {
   const item = document.createElement('div');
   item.className = `mobile-item item-${zone.id}`;
   item.dataset.popup = zone.id;
-  item.textContent = zone.popup.title;
+  const leftImg = document.createElement('img');
+  leftImg.src = zone.img;
+  leftImg.alt = zone.id;
+
+  const rightImg = document.createElement('img');
+  rightImg.src = zone.listLabel;
+  rightImg.alt = `${zone.id}-label`;
+
+  item.appendChild(leftImg);
+  item.appendChild(rightImg);
   mobileMenu.appendChild(item);
 });
 

--- a/style.css
+++ b/style.css
@@ -331,11 +331,13 @@ body.light-mode .audio-item button {
   border: 5px solid #000;
   display: flex;
   align-items: center;
-  justify-content: center;
-  font-size: 2rem;
-  font-weight: bold;
+  justify-content: space-between;
   cursor: pointer;
-  color: #000;
+}
+
+.mobile-item img {
+  height: 100%;
+  object-fit: contain;
 }
 
 .item-instrumentales { background: #bd75c4; }


### PR DESCRIPTION
## Summary
- replace mobile menu text with left/right images
- style mobile menu items to display images

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/al-one-lndlm.github.io/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689bd1794d1c832bbdae2c6558dcc9cc