### PR TITLE
Refine mobile layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -346,10 +346,25 @@ body.light-mode .audio-item button {
 .item-plugins        { background: #7d461d; }
 
 @media (max-width: 768px) {
+  :root {
+    --popup-font-size: 10px;
+    --popup-header-font-size: 16px;
+    --close-btn-font-size: 12px;
+    --audio-button-font-size: 12px;
+  }
+
   #mobile-menu {
     display: flex;
     flex-direction: column;
     height: 100vh;
+  }
+
+  .mobile-item img:first-child {
+    height: 70%;
+  }
+
+  .mobile-item img:last-child {
+    height: 28%;
   }
 
   #game-area {


### PR DESCRIPTION
## Summary
- Shrink text label images separately from building images in the mobile menu
- Reduce right-side mobile menu images to 28% height

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bd68bcc4c832b8a654bfd665c5c83