### PR TITLE
Make layout elements scale to viewport

### DIFF
--- a/config.js
+++ b/config.js
@@ -100,22 +100,22 @@ export const floatingImages = [
   {
     id: 'img1',
     src: 'assets/text1.png',
-    style: { top: '39vh', left: '7vw', width: '280px', height: '50px' }
+    style: { top: '39vh', left: '7vw', width: '20vw' }
   },
   {
     id: 'img2',
     src: 'assets/text2.png',
-    style: { top: '39vh', right: '7vw', width: '280px', height: '50px' }
+    style: { top: '39vh', right: '7vw', width: '20vw' }
   },
   {
     id: 'img3',
     src: 'assets/text3.png',
-    style: { bottom: '6vh', left: '7vw', width: '280px', height: '50px' }
+    style: { bottom: '6vh', left: '7vw', width: '20vw' }
   },
   {
     id: 'img4',
     src: 'assets/Fuente.png',
-    style: { bottom: '43vh', right: '46vw', width: '120px', height: '120px' }
+    style: { bottom: '43vh', right: '46vw', width: '6vw' }
   }
 ];
 

--- a/script.js
+++ b/script.js
@@ -11,6 +11,13 @@ const zonesContainer = document.getElementById('zones-container');
 const popupsContainer = document.getElementById('popups-container');
 const mobileMenu = document.getElementById('mobile-menu');
 
+// Ajuste de unidades vh en móviles
+function updateVh() {
+  document.documentElement.style.setProperty('--vh', `${window.innerHeight * 0.01}px`);
+}
+updateVh();
+window.addEventListener('resize', updateVh);
+
 // Objeto que guardará las ventanas emergentes generadas
 const popups = {};
 

--- a/style.css
+++ b/style.css
@@ -51,7 +51,7 @@ body.light-mode {
 #game-area {
   position: relative;
   width: 100vw;
-  height: 100vh;
+  height: calc(var(--vh, 1vh) * 100);
   background: var(--bg-dark) no-repeat center/cover;
 }
 
@@ -67,10 +67,11 @@ body.light-mode {
 }
 
 /* Zonas interactuables */
+
 .interactive-zone {
   position: absolute;
-  width: 311px;
-  height: 273px;
+  width: clamp(120px, 20vw, 311px);
+  height: auto;
   cursor: pointer;
   user-select: none;
   transition: transform 0.2s ease;
@@ -78,13 +79,22 @@ body.light-mode {
 }
 
 .interactive-zone:hover {
-  transform: scale(1.05);  
+  transform: scale(1.05);
+}
+
+@media (max-width: 480px) {
+  .interactive-zone {
+    width: 40vw;
+  }
 }
 
 /* Imágenes posicionables */
 .floating-image {
   position: absolute;
   user-select: none;
+  max-width: 100%;
+  height: auto;
+  object-fit: contain;
 }
 
 /* Obstáculo de prueba */
@@ -92,8 +102,8 @@ body.light-mode {
   position: fixed;
   top: 52%;
   left: 50%;
-  width: 50px;
-  height: 40px;
+  width: 2.6vw;
+  height: 3.7vh;
   background: rgba(255,0,0,0.0);
   border-radius: 12px;
   transform: translate(-50%, -50%);
@@ -101,29 +111,29 @@ body.light-mode {
   z-index: 5000;
 }
 
-#obstacle1 { 
-  top: 30%; 
-  left: 16%; 
-  width: 220px;
-  height: 90px;
+#obstacle1 {
+  top: 30%;
+  left: 16%;
+  width: 11.5vw;
+  height: 8.3vh;
 }
-#obstacle2 { 
-  top: 30%; 
-  left: 84%; 
-  width: 220px;
-  height: 90px;
-}
-#obstacle3 { 
-  top: 77%; 
-  left: 16%; 
-  width: 220px;
-  height: 90px;
-}
-#obstacle4 { 
-  top: 75%; 
+#obstacle2 {
+  top: 30%;
   left: 84%;
-  width: 220px;
-  height: 90px;
+  width: 11.5vw;
+  height: 8.3vh;
+}
+#obstacle3 {
+  top: 77%;
+  left: 16%;
+  width: 11.5vw;
+  height: 8.3vh;
+}
+#obstacle4 {
+  top: 75%;
+  left: 84%;
+  width: 11.5vw;
+  height: 8.3vh;
 }
 
 /* Ventanas emergentes genéricas */


### PR DESCRIPTION
## Summary
- Scale clickable building images with `vw` units and clamp for small screens
- Adjust floating labels and obstacles to use responsive widths
- Fix mobile viewport height using CSS variable updated on resize

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c8b805ee4832bb0273c8daff97256