### PR TITLE
Add mobile intro block above menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,11 @@
   <!-- Botón para cambiar entre modo claro y oscuro -->
   <button id="toggle-theme"></button>
 
+  <!-- Bloque de introducción para la versión móvil -->
+  <div id="mobile-intro">
+    <p>Bienvenido a Al.One</p>
+  </div>
+
   <div id="mobile-menu"></div>
 
   <!-- Área principal del "juego" con personaje y zonas -->

--- a/style.css
+++ b/style.css
@@ -334,6 +334,10 @@ body.light-mode .audio-item button {
   display: none;
 }
 
+#mobile-intro {
+  display: none;
+}
+
 .mobile-item {
   width: 100%;
   height: 22vh;
@@ -363,10 +367,20 @@ body.light-mode .audio-item button {
     --audio-button-font-size: 12px;
   }
 
+  body {
+    overflow-y: auto;
+  }
+
   #mobile-menu {
     display: flex;
     flex-direction: column;
-    height: 100vh;
+    height: auto;
+  }
+
+  #mobile-intro {
+    display: block;
+    padding: 20px;
+    text-align: center;
   }
 
   .mobile-item img:first-child {


### PR DESCRIPTION
## Summary
- add configurable intro block to mobile layout
- enable scrolling and style mobile introduction block

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cb702c828832bb3c84efe6263c9a3