### PR TITLE
Add mobile interactive game block

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,20 +19,23 @@
 
   <div id="mobile-menu"></div>
 
-  <!-- Área principal del "juego" con personaje y zonas -->
-  <div id="game-area">
-    <!-- Contenedor del sprite del personaje -->
-    <div id="character"></div>
+  <!-- Bloque interactivo para la versión móvil -->
+  <div id="mobile-game">
+    <!-- Área principal del "juego" con personaje y zonas -->
+    <div id="game-area">
+      <!-- Contenedor del sprite del personaje -->
+      <div id="character"></div>
 
-    <!-- Contenedor para inyectar las zonas clicables -->
-    <div id="zones-container"></div>
+      <!-- Contenedor para inyectar las zonas clicables -->
+      <div id="zones-container"></div>
 
-    <!-- Obstáculo central para pruebas -->
-    <div id="obstacle" class="obstacle"></div>
-    <div id="obstacle1" class="obstacle"></div>
-    <div id="obstacle2" class="obstacle"></div>
-    <div id="obstacle3" class="obstacle"></div>
-    <div id="obstacle4" class="obstacle"></div>
+      <!-- Obstáculo central para pruebas -->
+      <div id="obstacle" class="obstacle"></div>
+      <div id="obstacle1" class="obstacle"></div>
+      <div id="obstacle2" class="obstacle"></div>
+      <div id="obstacle3" class="obstacle"></div>
+      <div id="obstacle4" class="obstacle"></div>
+    </div>
   </div>
 
   <!-- Contenedor donde se crearán las ventanas emergentes -->

--- a/script.js
+++ b/script.js
@@ -224,14 +224,15 @@ setBackground();
 // =============================
 //  Animación del personaje
 // =============================
-let mouseX = 0, mouseY = 0;         // Posición actual del ratón
-let currentX = 0, currentY = 0;     // Posición actual del personaje
+const frameWidth = 90;              // Dimensiones de cada frame en el spritesheet
+const frameHeight = 90;
+let mouseX = gameArea.clientWidth / 2;
+let mouseY = gameArea.clientHeight / 2;         // Posición actual del ratón
+let currentX = gameArea.clientWidth / 2 - frameWidth / 2;
+let currentY = gameArea.clientHeight / 2 - frameHeight / 2;
 const speed = 0.006;                 // Velocidad de movimiento del personaje
 const offsetDistance = 0;          // Distancia respecto al cursor
 const idleThreshold = 80;            // Radio para activar animación "idle"
-
-const frameWidth = 90;              // Dimensiones de cada frame en el spritesheet
-const frameHeight = 90;
 const framesPerDirection = 4;       // Número de frames por dirección
 const directions = {
   'down-right': 0,
@@ -246,10 +247,14 @@ let frameTick = 0;                  // Control para la velocidad de animación
 
 const obstacles = Array.from(document.querySelectorAll('.obstacle'));
 
-document.addEventListener('mousemove', e => {
-  mouseX = e.clientX;
-  mouseY = e.clientY;
-});
+function updatePointerPosition(e) {
+  const rect = gameArea.getBoundingClientRect();
+  mouseX = e.clientX - rect.left;
+  mouseY = e.clientY - rect.top;
+}
+
+gameArea.addEventListener('pointermove', updatePointerPosition);
+gameArea.addEventListener('pointerdown', updatePointerPosition);
 
 /**
  * Determina si una posición colisiona con algún obstáculo.
@@ -260,13 +265,16 @@ document.addEventListener('mousemove', e => {
  * @returns {boolean} Verdadero si existe colisión
  */
 function isColliding(x, y, width = frameWidth, height = frameHeight) {
+  const areaRect = gameArea.getBoundingClientRect();
+  const globalX = x + areaRect.left;
+  const globalY = y + areaRect.top;
   return obstacles.some(ob => {
     const rect = ob.getBoundingClientRect();
     return (
-      x < rect.right &&
-      x + width > rect.left &&
-      y < rect.bottom &&
-      y + height > rect.top
+      globalX < rect.right &&
+      globalX + width > rect.left &&
+      globalY < rect.bottom &&
+      globalY + height > rect.top
     );
   });
 }

--- a/style.css
+++ b/style.css
@@ -391,7 +391,22 @@ body.light-mode .audio-item button {
     height: 28%;
   }
 
+  #mobile-game {
+    display: flex;
+    justify-content: center;
+    margin-top: 20px;
+  }
+
   #game-area {
+    display: block;
+    width: 90vw;
+    height: 90vw;
+    overflow: hidden;
+  }
+
+  #zones-container,
+  .floating-image,
+  .obstacle {
     display: none;
   }
 


### PR DESCRIPTION
## Summary
- Add mobile-only wrapper that exposes a square game area beneath the section list
- Style mobile game block and hide desktop-only elements
- Use pointer events and offset-aware collision for character control

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cbffcdd08832ba29e4a29998035c6