### PR TITLE
Add mobile-specific game block with pointer controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,19 @@
 
   <div id="mobile-menu"></div>
 
+  <!-- Bloque de juego para la versión móvil -->
+  <div id="mobile-game" style="display: none;">
+    <div id="mobile-game-area">
+      <div id="mobile-character"></div>
+      <div id="mobile-zones-container"></div>
+      <div id="mobile-obstacle" class="obstacle"></div>
+      <div id="mobile-obstacle1" class="obstacle"></div>
+      <div id="mobile-obstacle2" class="obstacle"></div>
+      <div id="mobile-obstacle3" class="obstacle"></div>
+      <div id="mobile-obstacle4" class="obstacle"></div>
+    </div>
+  </div>
+
   <!-- Área principal del "juego" con personaje y zonas -->
   <div id="game-area">
     <!-- Contenedor del sprite del personaje -->

--- a/style.css
+++ b/style.css
@@ -404,4 +404,69 @@ body.light-mode .audio-item button {
     width: 95vw;
     height: 90vh;
   }
+
+  #mobile-game {
+    display: block;
+  }
+
+  #mobile-game-area {
+    position: relative;
+    width: 100vw;
+    height: calc(var(--vh, 1vh) * 100);
+    background: var(--bg-dark) no-repeat center/cover;
+  }
+
+  #mobile-character {
+    position: absolute;
+    width: 90px;
+    height: 90px;
+    background: url('assets/spritesheet.png') no-repeat 0 0;
+    background-size: 360px 450px;
+    image-rendering: pixelated;
+    pointer-events: none;
+  }
+
+  #mobile-game-area .obstacle {
+    position: absolute;
+    background: rgba(255,0,0,0.0);
+    border-radius: 12px;
+    pointer-events: none;
+    z-index: 5000;
+  }
+
+  #mobile-obstacle {
+    top: 52%;
+    left: 50%;
+    width: 2.6vw;
+    height: 3.7vh;
+    transform: translate(-50%, -50%);
+  }
+
+  #mobile-obstacle1 {
+    top: 30%;
+    left: 16%;
+    width: 11.5vw;
+    height: 8.3vh;
+  }
+
+  #mobile-obstacle2 {
+    top: 30%;
+    left: 84%;
+    width: 11.5vw;
+    height: 8.3vh;
+  }
+
+  #mobile-obstacle3 {
+    top: 77%;
+    left: 16%;
+    width: 11.5vw;
+    height: 8.3vh;
+  }
+
+  #mobile-obstacle4 {
+    top: 75%;
+    left: 84%;
+    width: 11.5vw;
+    height: 8.3vh;
+  }
 }


### PR DESCRIPTION
## Summary
- Restore desktop game area and add separate `#mobile-game` with its own `#mobile-game-area` and obstacles.
- Duplicate zones for mobile, update backgrounds accordingly and implement `initMobileGame()` using pointer events and offset-based collision detection, activated via `matchMedia('(max-width: 768px)')`.
- Scope mobile styles under `@media (max-width: 768px)` to avoid affecting desktop layout.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_689cc76fdafc832baf1d4a6f5f23afea