### PR TITLE
feat: add mobile header with dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,14 @@
   <!-- Botón para cambiar entre modo claro y oscuro -->
   <button id="toggle-theme"></button>
 
+  <!-- Header compacto para la versión móvil -->
+  <header id="mobile-header">
+    <img id="mobile-logo" src="assets/logo-placeholder.png" alt="Logo" />
+    <button id="mobile-menu-toggle">
+      <img src="assets/menu-placeholder.png" alt="Menú" />
+    </button>
+  </header>
+
   <!-- Bloque de introducción para la versión móvil -->
   <div id="mobile-intro">
     <p>Bienvenido a Al.One</p>

--- a/script.js
+++ b/script.js
@@ -10,6 +10,7 @@ const toggleBtn = document.getElementById('toggle-theme');
 const zonesContainer = document.getElementById('zones-container');
 const popupsContainer = document.getElementById('popups-container');
 const mobileMenu = document.getElementById('mobile-menu');
+const mobileMenuToggle = document.getElementById('mobile-menu-toggle');
 const mobileGame = document.getElementById('mobile-game');
 const mobileGameArea = document.getElementById('mobile-game-area');
 const mobileCharacter = document.getElementById('mobile-character');
@@ -124,8 +125,17 @@ popupsContainer.addEventListener('click', e => {
 // Abrir ventana al seleccionar un elemento del menú móvil
 mobileMenu.addEventListener('click', e => {
   const target = e.target.closest('.mobile-item');
-  if (target) openPopup(target.dataset.popup);
+  if (target) {
+    openPopup(target.dataset.popup);
+    mobileMenu.classList.remove('open');
+  }
 });
+
+if (mobileMenuToggle) {
+  mobileMenuToggle.addEventListener('click', () => {
+    mobileMenu.classList.toggle('open');
+  });
+}
 
 /**
  * Muestra la ventana emergente asociada al identificador indicado

--- a/style.css
+++ b/style.css
@@ -47,6 +47,62 @@ body.light-mode {
   height: 40px;
 }
 
+/* Header móvil compacto */
+#mobile-header {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 50px;
+  padding: 0 10px;
+  box-sizing: border-box;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 10000;
+}
+
+#mobile-header img {
+  height: 32px;
+  display: block;
+}
+
+#mobile-menu-toggle {
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+#mobile-menu-toggle img {
+  height: 32px;
+}
+
+#mobile-menu {
+  display: none;
+  position: fixed;
+  top: 50px;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.85);
+  z-index: 9999;
+}
+
+#mobile-menu.open {
+  display: flex;
+  flex-direction: column;
+}
+
+body.light-mode #mobile-header {
+  background: rgba(255, 255, 255, 0.9);
+}
+
+body.light-mode #mobile-menu {
+  background: rgba(255, 255, 255, 0.95);
+  color: #000;
+}
+
 /* Contenedor principal */
 #game-area {
   position: relative;
@@ -330,10 +386,6 @@ body.light-mode .audio-item button {
   color: inherit;
 }
 
-#mobile-menu {
-  display: none;
-}
-
 #mobile-intro {
   display: none;
 }
@@ -371,9 +423,11 @@ body.light-mode .audio-item button {
     overflow-y: auto;
   }
 
-  #mobile-menu {
+  #mobile-header {
     display: flex;
-    flex-direction: column;
+  }
+
+  #mobile-menu {
     height: auto;
   }
 


### PR DESCRIPTION
## Summary
- add compact mobile header with placeholder icons
- toggle existing rectangular mobile menu from header button
- keep original content while enabling dropdown navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cd5f721d0832bbaa4f05bee068bd3