### PR TITLE
Add headers for contact popup columns

### DIFF
--- a/config.js
+++ b/config.js
@@ -53,6 +53,7 @@ export const zones = [
       content: `
         <div class="contact-popup">
           <div class="social-column">
+            <p class="column-title">Mis redes:</p>
             <a href="https://www.youtube.com/@LNDLM1312" target="_blank">
               <img src="assets/yt.png" alt="Twitter" style="width:144px;height:144px;margin:4px;" />
             </a>
@@ -61,6 +62,7 @@ export const zones = [
             </a>
           </div>
           <div class="form-column">
+            <p class="column-title">O escríbeme al correo:</p>
             <form id="contact-form" action="https://formspree.io/f/xldlzpew" method="POST">
               <label>
                 Nombre

--- a/style.css
+++ b/style.css
@@ -218,6 +218,12 @@ body.light-mode {
   transform: translateX(-50%);
 }
 
+.column-title {
+  font-family: 'PixelFont', monospace;
+  margin-bottom: 8px;
+  text-align: center;
+}
+
 .social-column {
   flex: 1;
   display: flex;


### PR DESCRIPTION
## Summary
- Show "Mis redes" above the social links in the contact popup
- Show "O escríbeme al correo" above the contact form
- Style column headers for consistent spacing and font

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ce985a83c832bbf60d906954b74b5