### PR TITLE
Adjust contact popup column alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -229,7 +229,16 @@ body.light-mode {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
+  padding-top: 20px;
+}
+
+.social-column a:first-of-type {
+  margin-top: auto;
+}
+
+.social-column a:last-of-type {
+  margin-bottom: auto;
 }
 
 .social-column img {
@@ -240,8 +249,10 @@ body.light-mode {
 .form-column {
   flex: 1;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
+  padding-top: 20px;
 }
 
 #contact-form {
@@ -250,6 +261,8 @@ body.light-mode {
   gap: 8px;
   font-family: 'PixelFont', monospace;
   margin: 0 auto;
+  margin-top: auto;
+  margin-bottom: auto;
 }
 
 #contact-form label {


### PR DESCRIPTION
## Summary
- Align contact popup columns to the top and stack content vertically
- Add top padding for social and form columns
- Center social icons and contact form vertically below their titles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ced827748832b90a1d7ebb465b018