### PR TITLE
feat: implement album and song levels in works popup

### DIFF
--- a/config.js
+++ b/config.js
@@ -26,19 +26,51 @@ export const zones = [
     img: 'assets/Edificio4.png',
     listLabel: 'assets/text2.png',
     position: { top: '3vh', right: '6vw' },
-    // Duplica el bloque <a class="video-card">…</a> para añadir más videos
     popup: {
       title: 'Trabajos',
       content: `
         <div class="trabajos-gallery">
-          <a class="video-card" href="https://www.youtube.com/watch?v=9gNmEuoKf7c&list=RD9gNmEuoKf7c&start_radio=1" target="_blank">
-            <div class="thumb" style="background-image:url('assets/mini1.jpg')"></div>
-            <p>El Niño y Su Fe (ALbumetraje Oficial)</p>
-          </a>
-          <a class="video-card" href="https://www.youtube.com/watch?v=oHg5SJYRHA0" target="_blank">
-            <div class="thumb" style="background-image:url('assets/mini1.jpg')"></div>
-            <p>Video ejemplo 2</p>
-          </a>
+          <!-- Álbum 1 -->
+          <div class="work-album">
+            <a class="thumb-link" href="https://www.youtube.com/playlist?list=ALBUM1" target="_blank">
+              <img class="thumb" src="assets/mini1.jpg" alt="Álbum 1">
+            </a>
+            <div class="info">
+              <a class="title-link" href="https://www.youtube.com/playlist?list=ALBUM1" target="_blank"><h3>Álbum 1</h3></a>
+              <p>Descripción breve del álbum.</p>
+            </div>
+          </div>
+
+          <!-- Canciones del Álbum 1 -->
+          <div class="work-song">
+            <a class="thumb-link" href="https://youtu.be/9gNmEuoKf7c" target="_blank"><img class="thumb" src="assets/mini1.jpg" alt="Canción 1"></a>
+            <a class="title-link" href="https://youtu.be/9gNmEuoKf7c" target="_blank">Canción 1</a>
+          </div>
+          <div class="work-song">
+            <a class="thumb-link" href="https://youtu.be/oHg5SJYRHA0" target="_blank"><img class="thumb" src="assets/mini1.jpg" alt="Canción 2"></a>
+            <a class="title-link" href="https://youtu.be/oHg5SJYRHA0" target="_blank">Canción 2</a>
+          </div>
+
+          <!-- Álbum 2 -->
+          <div class="work-album">
+            <a class="thumb-link" href="https://www.youtube.com/playlist?list=ALBUM2" target="_blank">
+              <img class="thumb" src="assets/mini1.jpg" alt="Álbum 2">
+            </a>
+            <div class="info">
+              <a class="title-link" href="https://www.youtube.com/playlist?list=ALBUM2" target="_blank"><h3>Álbum 2</h3></a>
+              <p>Otra descripción del álbum.</p>
+            </div>
+          </div>
+
+          <!-- Canciones del Álbum 2 -->
+          <div class="work-song">
+            <a class="thumb-link" href="https://youtu.be/oHg5SJYRHA0" target="_blank"><img class="thumb" src="assets/mini1.jpg" alt="Canción A"></a>
+            <a class="title-link" href="https://youtu.be/oHg5SJYRHA0" target="_blank">Canción A</a>
+          </div>
+          <div class="work-song">
+            <a class="thumb-link" href="https://youtu.be/oHg5SJYRHA0" target="_blank"><img class="thumb" src="assets/mini1.jpg" alt="Canción B"></a>
+            <a class="title-link" href="https://youtu.be/oHg5SJYRHA0" target="_blank">Canción B</a>
+          </div>
         </div>
       `
     }

--- a/style.css
+++ b/style.css
@@ -282,9 +282,8 @@ body.light-mode {
 /* Galería de videos en la ventana Trabajos */
 .trabajos-gallery {
   display: flex;
-  flex-wrap: wrap;
-  gap: 20px;
-  justify-content: center;
+  flex-direction: column;
+  gap: 10px;
 }
 
 .video-card {
@@ -306,6 +305,57 @@ body.light-mode {
 .video-card p {
   margin: 8px;
   text-align: center;
+}
+
+/* Niveles de trabajos */
+.work-album,
+.work-song {
+  display: flex;
+  align-items: center;
+}
+
+.work-album {
+  margin: 20px 0;
+}
+
+
+.work-album .thumb {
+  width: 320px;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+}
+
+.work-album .thumb-link {
+  margin-right: 15px;
+}
+
+.work-album .info h3 {
+  margin: 0;
+}
+
+.work-song {
+  margin-left: 40px;
+}
+
+.work-song .thumb {
+  width: 120px;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+}
+
+.work-song .thumb-link {
+  margin-right: 8px;
+}
+
+.work-album a,
+.work-song a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.work-album .title-link,
+.work-song .title-link {
+  display: inline-block;
 }
 
 /* Listado de instrumentales */


### PR DESCRIPTION
## Summary
- reorganize "Trabajos" popup to interleave album and song entries
- add CSS for album and song levels with thumbnails and layout
- refine entries with 16:9 thumbnails and links limited to titles and images

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a58cec7ebc832b9e78a17af4cfb1b6