### PR TITLE
Ajuste de miniaturas en ventana de Trabajos

### DIFF
--- a/style.css
+++ b/style.css
@@ -318,12 +318,20 @@ body.light-mode {
   margin: 20px 0;
 }
 
+
+/* Miniaturas de álbumes en ventana Trabajos */
 .work-album .thumb {
-  width: 320px;
+  width: 40vw;
   aspect-ratio: 16 / 9;
   height: auto;
   margin-right: 15px;
   object-fit: cover;
+}
+
+/* Borde para todas las miniaturas en Trabajos */
+.trabajos-gallery .thumb {
+  border: 5px solid #000;
+  box-sizing: border-box;
 }
 
 .work-album .info h3 {


### PR DESCRIPTION
## Summary
- Ajusta la miniatura de álbumes para usar el 40% del ancho de la ventana
- Añade borde negro ancho a todas las miniaturas de la galería de trabajos

## Testing
- `npm test` *(falla: no existe package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5dacb4608832bac7d2fefb33b6129