### PR TITLE
Add animated preloader overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,11 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+  <div id="preloader">
+    <div id="preloader-bar">
+      <div id="preloader-progress"></div>
+    </div>
+  </div>
   <!-- Botón para cambiar entre modo claro y oscuro -->
   <button id="toggle-theme"></button>
 

--- a/script.js
+++ b/script.js
@@ -3,6 +3,25 @@
 
 import { backgrounds, zones, instrumentals, floatingImages } from './config.js';
 
+const preloader = document.getElementById('preloader');
+const progress = document.getElementById('preloader-progress');
+const duration = 2500; // 2–3 segundos
+const start = Date.now();
+document.body.style.overflow = 'hidden';
+
+function animateLoader() {
+  const elapsed = Date.now() - start;
+  const pct = Math.min(elapsed / duration, 1);
+  progress.style.width = pct * 100 + '%';
+  if (pct < 1) {
+    requestAnimationFrame(animateLoader);
+  } else {
+    preloader.style.display = 'none';
+    document.body.style.overflow = 'auto';
+  }
+}
+animateLoader();
+
 // Referencias principales al DOM
 const gameArea = document.getElementById('game-area');
 const character = document.getElementById('character');

--- a/style.css
+++ b/style.css
@@ -1,5 +1,29 @@
 /* --- style.css --- */
 
+#preloader {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #000;
+  z-index: 10000;
+}
+#preloader-bar {
+  width: 80%;
+  max-width: 400px;
+  height: 8px;
+  background: #333;
+}
+#preloader-progress {
+  height: 100%;
+  width: 0;
+  background: #fff;
+}
+
 @font-face {
   font-family: 'PixelFont';
   src: url('assets/PixelFont.ttf') format('truetype');
@@ -38,7 +62,7 @@ body.light-mode {
   top: 10px;
   right: 10px;
   cursor: pointer;
-  z-index: 10000; /* Se asegura de que el botón quede por encima del área del juego */
+  z-index: 9999; /* Se asegura de que el botón quede por encima del área del juego */
 }
 
 #toggle-theme img {


### PR DESCRIPTION
## Summary
- Add preloader overlay markup to hide content during initial load
- Implement responsive preloader styles and adjust theme toggle stacking order
- Animate loading bar in script and manage body overflow during loading

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c1e56198832bb4e9768b823c6f6a