### PR TITLE
Improve mobile popup behavior

### DIFF
--- a/script.js
+++ b/script.js
@@ -3,11 +3,13 @@
 
 import { backgrounds, zones, instrumentals, floatingImages } from './config.js';
 
+const isMobile = window.matchMedia('(max-width: 768px)').matches;
+
 const preloader = document.getElementById('preloader');
 const progress = document.getElementById('preloader-progress');
 const duration = 2500; // 2–3 segundos
 const start = Date.now();
-document.body.style.overflow = 'hidden';
+document.body.style.overflow = isMobile ? 'auto' : 'hidden';
 
 function animateLoader() {
   const elapsed = Date.now() - start;
@@ -18,7 +20,7 @@ function animateLoader() {
   } else {
     preloader.style.display = 'none';
     // Mantén la página estática sin barras de desplazamiento
-    document.body.style.overflow = 'hidden';
+    document.body.style.overflow = isMobile ? 'auto' : 'hidden';
   }
 }
 animateLoader();
@@ -81,7 +83,7 @@ zones.forEach(zone => {
   // Ventana asociada
   const popup = document.createElement('div');
   popup.id = `popup-${zone.id}`;
-  popup.className = 'popup hidden';
+  popup.className = isMobile ? 'popup' : 'popup hidden';
   popup.innerHTML = `
     <div class="popup-header">
       ${zone.popup.title}
@@ -121,31 +123,33 @@ zones.forEach(zone => {
 // Crear listado de instrumentales
 populateInstrumentals();
 
-// Abrir ventana al hacer click en una zona
-zonesContainer.addEventListener('click', e => {
-  const target = e.target.closest('.interactive-zone');
-  if (target) openPopup(target.dataset.popup);
-});
-
-if (mobileZonesContainer) {
-  mobileZonesContainer.addEventListener('click', e => {
+if (!isMobile) {
+  // Abrir ventana al hacer click en una zona
+  zonesContainer.addEventListener('click', e => {
     const target = e.target.closest('.interactive-zone');
     if (target) openPopup(target.dataset.popup);
   });
-}
 
-// Cerrar ventana al pulsar su botón
-popupsContainer.addEventListener('click', e => {
-  if (e.target.matches('.close-btn')) {
-    closePopup(e.target.dataset.close);
+  if (mobileZonesContainer) {
+    mobileZonesContainer.addEventListener('click', e => {
+      const target = e.target.closest('.interactive-zone');
+      if (target) openPopup(target.dataset.popup);
+    });
   }
-});
 
-// Abrir ventana al seleccionar un elemento del menú móvil
-mobileMenu.addEventListener('click', e => {
-  const target = e.target.closest('.mobile-item');
-  if (target) openPopup(target.dataset.popup);
-});
+  // Cerrar ventana al pulsar su botón
+  popupsContainer.addEventListener('click', e => {
+    if (e.target.matches('.close-btn')) {
+      closePopup(e.target.dataset.close);
+    }
+  });
+
+  // Abrir ventana al seleccionar un elemento del menú móvil
+  mobileMenu.addEventListener('click', e => {
+    const target = e.target.closest('.mobile-item');
+    if (target) openPopup(target.dataset.popup);
+  });
+}
 
 /**
  * Muestra la ventana emergente asociada al identificador indicado
@@ -153,6 +157,7 @@ mobileMenu.addEventListener('click', e => {
  * @param {string} id Identificador de la ventana a mostrar
  */
 function openPopup(id) {
+  if (isMobile) return;
   Object.entries(popups).forEach(([key, p]) => {
     if (key === id) {
       p.classList.remove('hidden');
@@ -168,6 +173,7 @@ function openPopup(id) {
  * @param {string} id Identificador de la ventana a cerrar
  */
 function closePopup(id) {
+  if (isMobile) return;
   if (popups[id]) popups[id].classList.remove('visible');
   if (id === 'instrumentales' && currentAudio) {
     currentAudio.audio.pause();

--- a/style.css
+++ b/style.css
@@ -513,8 +513,11 @@ body.light-mode .audio-item button {
   }
 
   .popup {
-    width: 95vw;
-    height: 90vh;
+    position: static;
+    transform: none;
+    width: 100vw;
+    height: auto;
+    overflow-y: visible;
   }
 
   #mobile-game {


### PR DESCRIPTION
## Summary
- Make mobile popups fill the viewport width and height automatically
- Skip popup centering logic on mobile devices and disable related handlers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a2f7cd28832bad842de1ee63dfb6