### PR TITLE
Add black footer navigation to popups

### DIFF
--- a/script.js
+++ b/script.js
@@ -90,6 +90,12 @@ zones.forEach(zone => {
       <button class="close-btn" data-close="${zone.id}">X</button>
     </div>
     <div class="popup-content">${zone.popup.content || ''}</div>
+    <div class="popup-footer">
+      ${zones
+        .filter(z => z.id !== zone.id)
+        .map(z => `<a href="#" data-open="${z.id}">${z.popup.title}</a>`)
+        .join(' | ')}
+    </div>
   `;
   if (zone.popup.bg || zone.popup.gradient) {
     const layers = [];
@@ -146,6 +152,13 @@ if (mobileZonesContainer) {
 popupsContainer.addEventListener('click', e => {
   if (e.target.matches('.close-btn')) {
     closePopup(e.target.dataset.close);
+    return;
+  }
+
+  const link = e.target.closest('.popup-footer a');
+  if (link && link.dataset.open) {
+    e.preventDefault();
+    openPopup(link.dataset.open);
   }
 });
 

--- a/style.css
+++ b/style.css
@@ -238,6 +238,29 @@ body.light-mode {
   font-family: 'PixelFont', monospace;
 }
 
+.popup-footer {
+  background-color: #000;
+  color: #fff;
+  padding: 4px 8px;
+  height: 30px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  border-top: 2px solid #000;
+  font-size: var(--popup-font-size);
+  font-family: 'PixelFont', monospace;
+}
+
+.popup-footer a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.popup-footer a:hover {
+  text-decoration: underline;
+}
+
 .close-btn {
   background: none;
   border: 2px;


### PR DESCRIPTION
## Summary
- Add dynamic footer with links to other popups
- Style footer with black background and link hover
- Enable navigation between modals via footer links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae32207db0832b92a6fdcc64b0091a