### PR TITLE
Centraliza imagen de plugins con clase CSS

### DIFF
--- a/config.js
+++ b/config.js
@@ -192,7 +192,7 @@ export const zones = [
         title: 'Plugins',
         content:
           '<p style="text-align:center; margin-top:40px;"> Esta sección está en mantenimiento </p>' +
-          "<img src='assets/obra.png' alt='En obras' style='display:block; margin:30px auto; max-width:700px;'>",
+          '<img src="assets/obra.png" alt="En obras" class="plugin-img">',
         bg: 'assets/fondo.png',
         gradient: 'linear-gradient(to bottom, rgba(0,0,0,0.6), rgba(155, 129, 57, 0.78))'
       }

--- a/style.css
+++ b/style.css
@@ -678,3 +678,11 @@ body:not(.light-mode)::-webkit-scrollbar-thumb {
   border: 2px solid #000;
   border-radius: 0;
 }
+
+.plugin-img {
+  display: block;
+  width: 60%;
+  max-width: 60vw;
+  height: auto;
+  margin: 0 auto;
+}


### PR DESCRIPTION
## Summary
- Reemplaza el estilo en línea de la imagen en la sección de plugins por una clase reutilizable
- Define estilos `.plugin-img` para centrar y limitar el tamaño de la imagen

## Testing
- `npx playwright --version` *(failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ae36a65c2c832b98aad025f83b2ff8