### PR TITLE
Ensure popup footers visible and sticky

### DIFF
--- a/style.css
+++ b/style.css
@@ -202,6 +202,8 @@ body.light-mode {
   z-index: 9999;
   font-family: 'PixelFont', monospace;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
   opacity: 0;
   pointer-events: none;
   transition: transform 0.3s ease, opacity 0.3s ease;
@@ -232,7 +234,7 @@ body.light-mode {
 
 .popup-content {
   padding: 10px;
-  height: calc(100% - 70px);
+  flex: 1;
   overflow-y: auto;
   font-size: var(--popup-font-size);
   font-family: 'PixelFont', monospace;
@@ -250,6 +252,9 @@ body.light-mode {
   border-top: 2px solid #000;
   font-size: var(--popup-font-size);
   font-family: 'PixelFont', monospace;
+  flex-shrink: 0;
+  position: sticky;
+  bottom: 0;
 }
 
 .popup-footer a {
@@ -562,7 +567,9 @@ body.light-mode .audio-item button {
     transform: none;
     width: 100vw;
     height: 100vh;
-    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
     z-index: 10000;
   }
 


### PR DESCRIPTION
## Summary
- Make popup windows use flex layout so headers and footers display consistently on desktop
- Add sticky, non-shrinking footer that remains visible while scrolling
- Adjust mobile popup styles to match layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae37b2ba18832b87b360391fb18e7b