### PR TITLE
Aumentar el área del footer en móviles

### DIFF
--- a/style.css
+++ b/style.css
@@ -260,6 +260,7 @@ body.light-mode {
 .popup-footer a {
   color: inherit;
   text-decoration: none;
+  padding: 4px 8px;
 }
 
 .popup-footer a:hover {
@@ -575,6 +576,11 @@ body.light-mode .audio-item button {
 
   .popup.visible {
     transform: none;
+  }
+
+  .popup-footer {
+    padding: 12px 16px;
+    height: 60px;
   }
 
   #mobile-game {


### PR DESCRIPTION
## Summary
- Amplía el footer de las ventanas emergentes en móviles, elevando el texto para hacerlo más accesible
- Añade padding a los enlaces del footer para aumentar el área táctil

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3e7fa7bc832b9cf82ec9933fd7d2