### PR TITLE
Raise popup footer text positioning

### DIFF
--- a/style.css
+++ b/style.css
@@ -254,7 +254,7 @@ body.light-mode {
   font-family: 'PixelFont', monospace;
   flex-shrink: 0;
   position: sticky;
-  bottom: 0;
+  bottom: 10px;
 }
 
 .popup-footer a {
@@ -581,6 +581,7 @@ body.light-mode .audio-item button {
   .popup-footer {
     padding: 12px 16px;
     height: 60px;
+    bottom: 10px;
   }
 
   #mobile-game {


### PR DESCRIPTION
## Summary
- Shifted popup footers 10px above the bottom edge to bring their text higher.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae45da5d70832ba8e21c7515b2a612