### PR TITLE
Fix mobile background scroll when popups open

### DIFF
--- a/script.js
+++ b/script.js
@@ -182,6 +182,10 @@ function openPopup(id) {
       p.classList.remove('visible');
     }
   });
+  if (isMobile) {
+    document.documentElement.style.overflow = 'hidden';
+    document.body.style.overflow = 'hidden';
+  }
 }
 
 /**
@@ -195,6 +199,13 @@ function closePopup(id) {
     currentAudio.audio.currentTime = 0;
     currentAudio.button.textContent = '▶';
     currentAudio = null;
+  }
+  if (isMobile) {
+    const anyVisible = Object.values(popups).some(p => p.classList.contains('visible'));
+    if (!anyVisible) {
+      document.documentElement.style.overflow = 'auto';
+      document.body.style.overflow = 'auto';
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Prevent background scrolling on mobile while popups are open
- Restore page scroll after closing the last popup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af27e74a34832ba9e0259ab9f81164