### PR TITLE
Allow vertical scrolling on mobile devices

### DIFF
--- a/script.js
+++ b/script.js
@@ -10,6 +10,7 @@ const progress = document.getElementById('preloader-progress');
 const duration = 2500; // 2–3 segundos
 const start = Date.now();
 document.body.style.overflow = isMobile ? 'auto' : 'hidden';
+document.documentElement.style.overflow = isMobile ? 'auto' : 'hidden';
 
 function animateLoader() {
   const elapsed = Date.now() - start;
@@ -21,6 +22,7 @@ function animateLoader() {
     preloader.style.display = 'none';
     // Mantén la página estática sin barras de desplazamiento
     document.body.style.overflow = isMobile ? 'auto' : 'hidden';
+    document.documentElement.style.overflow = isMobile ? 'auto' : 'hidden';
   }
 }
 animateLoader();

--- a/style.css
+++ b/style.css
@@ -62,11 +62,9 @@ body {
 }
 
 @media (max-width: 768px) {
-  html {
-    overflow-y: auto;
-  }
-
+  html,
   body {
+    overflow-x: hidden;
     overflow-y: auto;
   }
 }


### PR DESCRIPTION
## Summary
- Adjust mobile media query to allow vertical scrolling while keeping horizontal overflow hidden.
- Sync body and documentElement overflow styles with mobile detection in script.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af330fa4e0832ba79cae6cd4d36fea