### PR TITLE
Display responsive mobile intro image

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 
   <!-- Bloque de introducción para la versión móvil -->
   <div id="mobile-intro">
-    <p>Bienvenido a Al.One</p>
+    <img src="assets/fondomovil.png" alt="Introducción" />
   </div>
 
   <div id="mobile-menu"></div>

--- a/style.css
+++ b/style.css
@@ -551,8 +551,18 @@ body.light-mode .audio-item button {
 
   #mobile-intro {
     display: block;
-    padding: 20px;
-    text-align: center;
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+    position: relative;
+    z-index: 0;
+  }
+
+  #mobile-intro img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
   }
 
   .mobile-item img:first-child {


### PR DESCRIPTION
## Summary
- Replace mobile welcome text with `fondomovil.png` image
- Style mobile intro section to cover full viewport and sit beneath character overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af5094b238832ba442f3bd2c5f18c3