### PR TITLE
Add mobile header with toggle menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,12 +18,21 @@
   <!-- Botón para cambiar entre modo claro y oscuro -->
   <button id="toggle-theme"></button>
 
+  <!-- Encabezado móvil -->
+  <header id="mobile-header">
+    <a href="/" id="mobile-logo">
+      <img src="assets/LogoNombre.png" alt="Logo" />
+    </a>
+    <img src="assets/IconoAbrirMenu.png" alt="Abrir menú" id="menu-icon" />
+  </header>
+
   <!-- Bloque de introducción para la versión móvil -->
   <div id="mobile-intro">
     <img src="assets/fondomovil.png" alt="Introducción" />
   </div>
 
   <div id="mobile-menu"></div>
+  <div id="mobile-menu-overlay"></div>
 
   <!-- Bloque de juego para la versión móvil -->
   <div id="mobile-game" style="display: none;">

--- a/script.js
+++ b/script.js
@@ -34,9 +34,11 @@ const toggleBtn = document.getElementById('toggle-theme');
 const zonesContainer = document.getElementById('zones-container');
 const popupsContainer = document.getElementById('popups-container');
 const mobileMenu = document.getElementById('mobile-menu');
+const mobileMenuOverlay = document.getElementById('mobile-menu-overlay');
 const mobileGame = document.getElementById('mobile-game');
 const mobileCharacter = document.getElementById('mobile-character');
 const mobileZonesContainer = document.getElementById('mobile-zones-container');
+const menuIcon = document.getElementById('menu-icon');
 
 // Ajuste de unidades vh en móviles
 function updateVh() {
@@ -115,11 +117,12 @@ zones.forEach(zone => {
   });
 });
 
-// Menú móvil generado dinámicamente
+// Menú móvil generado dinámicamente (lista de secciones)
 zones.forEach(zone => {
   const item = document.createElement('div');
   item.className = `mobile-item item-${zone.id}`;
   item.dataset.popup = zone.id;
+
   const leftImg = document.createElement('img');
   leftImg.src = zone.img;
   leftImg.alt = zone.id;
@@ -131,6 +134,24 @@ zones.forEach(zone => {
   item.appendChild(leftImg);
   item.appendChild(rightImg);
   mobileMenu.appendChild(item);
+});
+
+// Menú superpuesto para el encabezado móvil
+zones.forEach((zone, idx) => {
+  const item = document.createElement('a');
+  item.className = 'menu-link';
+  item.dataset.popup = zone.id;
+
+  const labelImg = document.createElement('img');
+  labelImg.src = zone.listLabel;
+  labelImg.alt = zone.id;
+
+  item.appendChild(labelImg);
+  mobileMenuOverlay.appendChild(item);
+
+  if (idx < zones.length - 1) {
+    mobileMenuOverlay.appendChild(document.createElement('hr'));
+  }
 });
 
 // Crear listado de instrumentales
@@ -163,7 +184,29 @@ popupsContainer.addEventListener('click', e => {
   }
 });
 
-// Abrir ventana al seleccionar un elemento del menú móvil
+// Manejo del menú móvil
+let menuOpen = false;
+
+if (menuIcon) {
+  menuIcon.addEventListener('click', () => {
+    menuOpen = !menuOpen;
+    mobileMenuOverlay.classList.toggle('open', menuOpen);
+    menuIcon.src = menuOpen
+      ? 'assets/IconoCerrarMenu.png'
+      : 'assets/IconoAbrirMenu.png';
+  });
+}
+
+mobileMenuOverlay.addEventListener('click', e => {
+  const target = e.target.closest('.menu-link');
+  if (target) {
+    openPopup(target.dataset.popup);
+    mobileMenuOverlay.classList.remove('open');
+    if (menuIcon) menuIcon.src = 'assets/IconoAbrirMenu.png';
+    menuOpen = false;
+  }
+});
+
 mobileMenu.addEventListener('click', e => {
   const target = e.target.closest('.mobile-item');
   if (target) openPopup(target.dataset.popup);

--- a/style.css
+++ b/style.css
@@ -506,6 +506,10 @@ body.light-mode .audio-item button {
   display: none;
 }
 
+#mobile-menu-overlay {
+  display: none;
+}
+
 #mobile-intro {
   display: none;
 }
@@ -543,10 +547,76 @@ body.light-mode .audio-item button {
     overflow-y: auto;
   }
 
+  #mobile-header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 20px;
+    background: transparent;
+    z-index: 2000;
+  }
+
+  #mobile-header img {
+    height: 40px;
+  }
+
+  #menu-icon {
+    cursor: pointer;
+  }
+
   #mobile-menu {
     display: flex;
     flex-direction: column;
     height: auto;
+  }
+
+  #mobile-menu-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background: rgba(0, 0, 0, 0.8);
+    display: none;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    z-index: 1500;
+  }
+
+  #mobile-menu-overlay.open {
+    display: flex;
+  }
+
+  #mobile-menu-overlay .menu-link {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+  }
+
+  #mobile-menu-overlay .menu-link img {
+    width: 60%;
+    max-width: 300px;
+  }
+
+  #mobile-menu-overlay hr {
+    width: 100%;
+    border: none;
+    border-top: 1px solid #fff;
+    margin: 20px 0;
+  }
+
+  .mobile-item img:first-child {
+    height: 70%;
+  }
+
+  .mobile-item img:last-child {
+    height: 20%;
+    margin-right: 5%;
   }
 
   #mobile-intro {
@@ -563,15 +633,6 @@ body.light-mode .audio-item button {
     height: 100%;
     object-fit: cover;
     display: block;
-  }
-
-  .mobile-item img:first-child {
-    height: 70%;
-  }
-
-  .mobile-item img:last-child {
-    height: 20%;
-    margin-right: 5%;
   }
 
   #game-area {


### PR DESCRIPTION
## Summary
- Keep original mobile section list alongside new toggle menu
- Add fullscreen semi-transparent overlay menu triggered by header icon
- Update scripts and styles to swap menu icons and open targeted sections

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af5dbf75f0832b9d4cc57ba4da6dea