### PR TITLE
Add final mobile background image

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,9 @@
   </div>
 
   <div id="mobile-menu"></div>
+  <div id="mobile-final">
+    <img src="assets/fondomovilfinal.png" alt="Fondo final" />
+  </div>
   <div id="mobile-menu-overlay"></div>
 
   <!-- Bloque de juego para la versión móvil -->

--- a/style.css
+++ b/style.css
@@ -519,6 +519,10 @@ body.light-mode .audio-item button {
   display: none;
 }
 
+#mobile-final {
+  display: none;
+}
+
 .mobile-item {
   width: 100%;
   height: 22vh;
@@ -587,6 +591,16 @@ body.light-mode .audio-item button {
     display: flex;
     flex-direction: column;
     height: auto;
+  }
+
+  #mobile-final {
+    display: block;
+  }
+
+  #mobile-final img {
+    width: 100%;
+    height: auto;
+    display: block;
   }
 
   #mobile-menu-overlay {


### PR DESCRIPTION
## Summary
- add final background image for mobile screens
- include styles to show image only on mobile and keep character overlaying

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68af81c2d8bc832b82ee4b8b360e49c1