### PR TITLE
Centrar y recortar imagen final en móviles

### DIFF
--- a/style.css
+++ b/style.css
@@ -595,11 +595,17 @@ body.light-mode .audio-item button {
 
   #mobile-final {
     display: block;
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+    position: relative;
+    z-index: 0;
   }
 
   #mobile-final img {
     width: 100%;
-    height: auto;
+    height: 100%;
+    object-fit: cover;
     display: block;
   }
 


### PR DESCRIPTION
## Summary
- Ajusta la imagen final de la versión móvil para que se centre y se recorte según el ancho de pantalla, replicando el comportamiento de la imagen inicial

## Testing
- `npm test` *(no se encontró `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68af88e5c09c832b9df759e1457be819