### PR TITLE
Add separators for work thumbnails

### DIFF
--- a/style.css
+++ b/style.css
@@ -394,6 +394,12 @@ body.light-mode {
   align-items: center;
 }
 
+/* Separador para miniaturas de primer nivel en Trabajos */
+.trabajos-gallery > * + * {
+  border-top: 2px solid #000;
+  padding-top: 10px;
+}
+
 .video-card {
   width: 400px;
   background: #000;
@@ -424,6 +430,7 @@ body.light-mode {
 
 .work-album {
   margin: 20px 0;
+  align-self: stretch;
 }
 
 
@@ -452,8 +459,9 @@ body.light-mode {
 }
 
 .work-song {
-  margin-left: 40px;
-  align-self: flex-start;
+  padding-left: 40px;
+  align-self: stretch;
+  box-sizing: border-box;
 }
 
 .work-song .thumb {
@@ -768,11 +776,7 @@ body.light-mode .audio-item button {
     align-items: center;
     text-align: center;
     margin-left: 0;
-  }
-
-   .work-song {
-    margin-left: 0;
-    align-self: center;
+    padding-left: 0;
   }
  
   .work-album .thumb,


### PR DESCRIPTION
## Summary
- add CSS separator lines above each work thumbnail after the first
- stretch work items and adjust padding so separators span the full popup on desktop and mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b032d0ae04832b9a2868f4a7bcc2da