### PR TITLE
Highlight second album thumbnail only

### DIFF
--- a/config.js
+++ b/config.js
@@ -93,7 +93,7 @@ export const zones = [
           </div>
 
           <!-- Álbum 2 -->
-          <div class="work-album">
+          <div class="work-album album-divider">
             <a class="album-link" href="https://youtu.be/qGOawjmFM8A?si=CpSVPV51H_c76tt9" target="_blank">
               <img class="thumb" src="assets/TDB0.webp" alt="Álbum 2">
             </a>

--- a/style.css
+++ b/style.css
@@ -394,10 +394,9 @@ body.light-mode {
   align-items: center;
 }
 
-/* Separador para miniaturas de primer nivel en Trabajos */
+/* Espaciado entre elementos en Trabajos */
 .trabajos-gallery > * + * {
-  border-top: 2px solid #000;
-  padding-top: 10px;
+  margin-top: 10px;
 }
 
 .video-card {
@@ -431,6 +430,13 @@ body.light-mode {
 .work-album {
   margin: 20px 0;
   align-self: stretch;
+}
+
+/* Separador antes del segundo álbum */
+.work-album.album-divider {
+  border-top: 5px solid #000;
+  margin-top: 30px;
+  padding-top: 20px;
 }
 
 


### PR DESCRIPTION
## Summary
- Restrict inter-item separator to apply only before the second album
- Add dedicated style for second album with thicker divider and extra spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0383141cc832bb325fa934bc09439