### PR TITLE
feat: add welcome popup with image slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,20 @@
       <div id="preloader-progress"></div>
     </div>
   </div>
+  <!-- Ventana emergente de bienvenida -->
+  <div id="welcome-modal" class="welcome-modal hidden">
+    <div class="welcome-content">
+      <h2>Bienvenido</h2>
+      <p>Explora el mundo de Al.One y descubre todas sus sorpresas.</p>
+      <h3>Galería</h3>
+      <div class="slider">
+        <button id="slider-prev" class="slider-btn">&#9664;</button>
+        <img id="slider-image" src="assets/text1.png" alt="Galería" />
+        <button id="slider-next" class="slider-btn">&#9654;</button>
+      </div>
+      <button id="explore-btn">Explorar</button>
+    </div>
+  </div>
   <!-- Botón para cambiar entre modo claro y oscuro -->
   <button id="toggle-theme"></button>
 

--- a/script.js
+++ b/script.js
@@ -12,6 +12,51 @@ const start = Date.now();
 document.body.style.overflow = isMobile ? 'auto' : 'hidden';
 document.documentElement.style.overflow = isMobile ? 'auto' : 'hidden';
 
+// Elementos de la ventana de bienvenida
+const welcomeModal = document.getElementById('welcome-modal');
+const sliderImage = document.getElementById('slider-image');
+const prevImageBtn = document.getElementById('slider-prev');
+const nextImageBtn = document.getElementById('slider-next');
+const exploreBtn = document.getElementById('explore-btn');
+const welcomeImages = [
+  'assets/text1.png',
+  'assets/text2.png',
+  'assets/text3.png',
+  'assets/text4.png'
+];
+let currentSlide = 0;
+
+function updateSlide() {
+  if (sliderImage) {
+    sliderImage.src = welcomeImages[currentSlide];
+  }
+}
+
+function showWelcome() {
+  if (welcomeModal) {
+    welcomeModal.classList.remove('hidden');
+  }
+}
+
+if (prevImageBtn && nextImageBtn) {
+  prevImageBtn.addEventListener('click', () => {
+    currentSlide = (currentSlide - 1 + welcomeImages.length) % welcomeImages.length;
+    updateSlide();
+  });
+  nextImageBtn.addEventListener('click', () => {
+    currentSlide = (currentSlide + 1) % welcomeImages.length;
+    updateSlide();
+  });
+}
+
+if (exploreBtn) {
+  exploreBtn.addEventListener('click', () => {
+    welcomeModal.classList.add('hidden');
+  });
+}
+
+updateSlide();
+
 function animateLoader() {
   const elapsed = Date.now() - start;
   const pct = Math.min(elapsed / duration, 1);
@@ -23,6 +68,7 @@ function animateLoader() {
     // Mantén la página estática sin barras de desplazamiento
     document.body.style.overflow = isMobile ? 'auto' : 'hidden';
     document.documentElement.style.overflow = isMobile ? 'auto' : 'hidden';
+    showWelcome();
   }
 }
 animateLoader();

--- a/style.css
+++ b/style.css
@@ -93,6 +93,62 @@ body.light-mode {
   height: 40px;
 }
 
+/* Ventana emergente de bienvenida */
+.welcome-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10001;
+}
+
+.welcome-modal.hidden {
+  display: none;
+}
+
+.welcome-content {
+  background: #fff;
+  color: #000;
+  padding: 20px;
+  text-align: center;
+  max-width: 500px;
+  font-family: 'PixelFont', monospace;
+}
+
+.slider {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  margin: 10px 0;
+}
+
+.slider img {
+  max-width: 100%;
+  height: auto;
+}
+
+.slider-btn {
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  color: #000;
+}
+
+#explore-btn {
+  margin-top: 10px;
+  padding: 8px 16px;
+  font-size: 16px;
+  cursor: pointer;
+  font-family: 'PixelFont', monospace;
+}
+
 /* Contenedor principal */
 #game-area {
   position: relative;


### PR DESCRIPTION
## Summary
- show a welcome modal with introductory text and gallery slider on page load
- add image navigation and explore button that dismisses the modal

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b07067ec00832bb9abd37e520840a0