### PR TITLE
Add mobile social icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,14 @@
   <div id="mobile-menu"></div>
   <div id="mobile-final">
     <img src="assets/fondomovilfinal.png" alt="Fondo final" />
+    <div id="mobile-social">
+      <a href="https://www.youtube.com/@LNDLM1312" target="_blank">
+        <img src="assets/yt.png" alt="YouTube" />
+      </a>
+      <a href="https://www.instagram.com/al.one.wav/" target="_blank">
+        <img src="assets/insta.png" alt="Instagram" />
+      </a>
+    </div>
   </div>
   <div id="mobile-menu-overlay"></div>
 

--- a/style.css
+++ b/style.css
@@ -689,6 +689,21 @@ body.light-mode .audio-item button {
     display: block;
   }
 
+  #mobile-social {
+    position: absolute;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    gap: 20px;
+    z-index: 1;
+  }
+
+  #mobile-social img {
+    width: 48px;
+    height: auto;
+  }
+
   #mobile-menu-overlay {
     position: fixed;
     top: 0;


### PR DESCRIPTION
## Summary
- add YouTube and Instagram icons at the bottom of the mobile page
- style icons to sit above the final mobile image with 20px gap

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b08c3440f4832b95016ad8fe39da19