### PR TITLE
Ajustar tamaño de elementos 'Trabajos' en móvil para evitar desbordes

### DIFF
--- a/style.css
+++ b/style.css
@@ -1307,6 +1307,8 @@ body.light-mode .audio-item button {
     flex-direction: column;
     align-items: center;
     text-align: center;
+    width: 100%;
+    max-width: 100%;
     margin-left: 0;
     padding-left: 0;
   }
@@ -1318,11 +1320,11 @@ body.light-mode .audio-item button {
   }
 
   .work-album .thumb {
-    width: 90vw;
+    width: min(100%, 300px);
   }
 
   .work-song .thumb {
-    width: 65vw;
+    width: min(85%, 220px);
   }
 
 }


### PR DESCRIPTION
### Motivation
- Evitar que los elementos de la ventana "Trabajos" en la vista móvil sobresalgan del popup/viewport y toquen los bordes de la ventana.

### Description
- En `style.css` dentro del media query móvil se limitaron los contenedores `.work-album` y `.work-song` a `width: 100%`/`max-width: 100%` y se redujeron las miniaturas usando `width: min(100%, 300px)` para `.work-album .thumb` y `width: min(85%, 220px)` para `.work-song .thumb` para que no desborden.

### Testing
- Verificación del diff con `git diff -- style.css` y revisión de las reglas CSS aplicadas, arranque de un servidor local con `python3 -m http.server 8000` (exitoso) y intento de captura con Playwright que falló por limitaciones del entorno (no se pudo cargar/renderizar la página para el screenshot).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7f61786c8832bb11d0e4f5117db9e)