### PR TITLE
Alinear elementos de Trabajos en móvil y justificar textos

### DIFF
--- a/style.css
+++ b/style.css
@@ -1299,18 +1299,25 @@ body.light-mode .audio-item button {
 
   .trabajos-gallery .thumb {
     display: block;
-    margin: 0 auto;
+    margin: 0;
   }
 
   .work-album,
   .work-song {
     flex-direction: column;
-    align-items: center;
-    text-align: center;
+    align-items: flex-start;
+    text-align: left;
     width: 100%;
     max-width: 100%;
     margin-left: 0;
     padding-left: 0;
+  }
+
+  .work-album .info,
+  .work-song .info,
+  .album-description p {
+    width: 100%;
+    text-align: justify;
   }
  
   .work-album .thumb,


### PR DESCRIPTION
### Motivation
- Mejorar la apariencia móvil de la ventana "Trabajos" para que las miniaturas y textos queden alineados a la izquierda y la lectura sea más equilibrada.
- Evitar el centrado automático de las miniaturas que rompía la jerarquía visual en pantallas pequeñas.
- Garantizar que las descripciones tengan un aspecto profesional mediante justificación del texto.

### Description
- En `style.css` para el bloque responsive móvil se cambió `.trabajos-gallery .thumb` a `margin: 0` para quitar el centrado automático y permitir alineación a la izquierda.
- Se actualizó `.work-album, .work-song` para usar `align-items: flex-start` y `text-align: left` para alinear los elementos del listado hacia la izquierda en móvil.
- Se añadió el bloque `.work-album .info, .work-song .info, .album-description p { width: 100%; text-align: justify; }` para justificar las descripciones y contenidos informativos.

### Testing
- Se ejecutó la búsqueda con `rg -n "Trabajos|trabajos|work|mini" index.html style.css script.js` para verificar las ubicaciones de estilo y plantilla y la prueba fue satisfactoria.
- Se levantó un servidor local con `python3 -m http.server 4173 --bind 0.0.0.0` para validar visualmente el cambio y el servidor respondió correctamente.
- Se corrió un script de Playwright para abrir la vista móvil, pulsar la sección `trabajos` y generar una captura de pantalla; el primer intento falló por un problema de disponibilidad del servidor, y el segundo intento fue exitoso y produjo la captura de pantalla de validación.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7f8806870832ba151825bf68427ac)