### PR TITLE
Mobile: place album titles above thumbnails in Trabajos popup

### DIFF
--- a/style.css
+++ b/style.css
@@ -1313,6 +1313,33 @@ body.light-mode .audio-item button {
     padding-left: 0;
   }
 
+  /* Solo para álbumes: título arriba, miniatura debajo y descripción después */
+  .work-album {
+    display: grid;
+    grid-template-areas:
+      'album-title'
+      'album-thumb'
+      'album-description';
+    row-gap: 0;
+  }
+
+  .work-album > .album-link {
+    grid-area: album-thumb;
+  }
+
+  .work-album > .info {
+    display: contents;
+  }
+
+  .work-album > .info h3 {
+    grid-area: album-title;
+    margin-bottom: 8px;
+  }
+
+  .work-album > .info .album-description {
+    grid-area: album-description;
+  }
+
   .work-album .info,
   .work-song .info,
   .album-description p {


### PR DESCRIPTION
### Motivation
- The Trabajos popup on small screens should show album titles above their thumbnails for clearer hierarchy while keeping song rows and descriptions in their current positions.

### Description
- Updated `style.css` in the mobile-specific trabajos styles to add a grid layout for `.work-album` using `grid-template-areas` to order `album-title`, `album-thumb`, and `album-description`.
- Added rules to map the existing `.album-link`, `.info h3`, and `.album-description` into the new grid, using `display: contents` on `.info` to avoid altering internal markup flow.
- Scoped the changes to `.work-album` inside the mobile adjustments so `.work-song` layout and song title/description behavior remain unchanged.
- Change consists of a single file modification: `style.css` (mobile trabajos block).

### Testing
- Launched a local static server with `python3 -m http.server 4173` to serve the site for visual validation and automated checks.
- Ran a Playwright script with a mobile viewport (`width=390,height=844`) that opens the page, navigates to the Trabajos item, and captures a screenshot; the second run completed successfully and produced a screenshot artifact showing the album title above the thumbnail.
- The first Playwright attempt timed out at 30s, but a second attempt with increased timeout succeeded, and the automated run produced the expected layout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7fca65964832bbd3d054eaeab0715)