### PR TITLE
Corrige bloqueo de scroll en móvil tras cerrar popups

### DIFF
--- a/script.js
+++ b/script.js
@@ -248,6 +248,10 @@ function syncPopupBackdrop() {
   popupBackdrop.classList.toggle('active', anyVisible);
   popupBackdrop.setAttribute('aria-hidden', anyVisible ? 'false' : 'true');
   document.body.classList.toggle('popup-open', anyVisible);
+  if (isMobile) {
+    document.documentElement.style.overflow = anyVisible ? 'hidden' : 'auto';
+    document.body.style.overflow = anyVisible ? 'hidden' : 'auto';
+  }
 }
 
 // Menú móvil generado dinámicamente (lista de secciones)
@@ -726,10 +730,6 @@ function openPopup(id, push = true) {
     history.pushState({ popupId: id }, '');
   }
   syncPopupBackdrop();
-  if (isMobile) {
-    document.documentElement.style.overflow = 'hidden';
-    document.body.style.overflow = 'hidden';
-  }
 }
 
 /**
@@ -746,13 +746,6 @@ function closePopup(id) {
     currentAudio.audio.currentTime = 0;
     currentAudio.button.textContent = '▶';
     currentAudio = null;
-  }
-  if (isMobile) {
-    const anyVisible = Object.values(popups).some(hasActivePopup);
-    if (!anyVisible) {
-      document.documentElement.style.overflow = 'auto';
-      document.body.style.overflow = 'auto';
-    }
   }
   syncPopupBackdrop();
 }


### PR DESCRIPTION
### Motivation
- Al abrir y cerrar ventanas emergentes en móvil la página principal quedaba inmovilizada porque distintas partes del código gestionaban `overflow` de `document.documentElement` y `document.body` de forma desincronizada.

### Description
- Centraliza la lógica de bloqueo/desbloqueo de scroll en la función `syncPopupBackdrop()` para que el estado de `overflow` siempre refleje si hay algún popup activo. 
- Elimina las actualizaciones duplicadas de `overflow` en `openPopup()` y en `closePopup()` para evitar estados obsoletos durante las transiciones de cierre. 
- Mantiene la llamada a `syncPopupBackdrop()` desde el `transitionend` de cada popup para restaurar correctamente el scroll cuando las animaciones terminan.

### Testing
- Ejecutado `node --check script.js` y la comprobación de sintaxis ha pasado correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7fe5faed0832bb2f4585fb040f52a)