### PR TITLE
Añadir contenedor base 'Covers' en acordeón móvil del popup de música

### DIFF
--- a/script.js
+++ b/script.js
@@ -797,6 +797,13 @@ function populateMobileMusicSections() {
     content.className = 'mobile-music-accordion__content';
     content.dataset.section = section.key;
 
+    if (section.key === 'covers') {
+      const coversContainer = document.createElement('div');
+      coversContainer.className = 'mobile-covers-container';
+      coversContainer.dataset.section = 'covers-container';
+      content.appendChild(coversContainer);
+    }
+
     block.appendChild(summary);
     block.appendChild(content);
     container.appendChild(block);

--- a/style.css
+++ b/style.css
@@ -1264,6 +1264,13 @@ body.light-mode .audio-item button {
     background: rgba(0, 0, 0, 0.35);
   }
 
+  .mobile-covers-container {
+    min-height: 100px;
+    margin: 10px;
+    border: 2px dashed rgba(255, 255, 255, 0.7);
+    background: rgba(0, 0, 0, 0.25);
+  }
+
   body.light-mode .mobile-music-accordion {
     background: linear-gradient(180deg, rgba(239, 239, 239, 0.95), rgba(213, 213, 213, 0.95));
     color: #000;
@@ -1272,6 +1279,11 @@ body.light-mode .audio-item button {
 
   body.light-mode .mobile-music-accordion__content {
     background: rgba(255, 255, 255, 0.55);
+  }
+
+  body.light-mode .mobile-covers-container {
+    border-color: rgba(0, 0, 0, 0.45);
+    background: rgba(255, 255, 255, 0.35);
   }
 
   #mobile-game {


### PR DESCRIPTION
### Motivation
- Preparar la sección móvil de "Covers" dentro del popup de música para poder alojar futuros elementos sin modificar la estructura del acordeón.

### Description
- Se añadió la creación dinámica de un `div` con clase `mobile-covers-container` cuando la sección es `covers` en `populateMobileMusicSections()` en `script.js`.
- Se añadieron estilos base para `.mobile-covers-container` en `style.css` para modo normal (borde, fondo, margen y `min-height`).
- Se añadió una variante de estilos para `body.light-mode .mobile-covers-container` para mantener consistencia con el tema claro.
- Los cambios mantienen la estructura del acordeón existente y dejan el contenedor listo para insertar elementos posteriormente.

### Testing
- Se ejecutó `node --check script.js` y la comprobación de sintaxis fue exitosa.
- Se levantó un servidor local (`python3 -m http.server 4173`) y se verificó visualmente mediante una captura automatizada con Playwright que el contenedor aparece dentro del acordeón `Covers` en viewport móvil, prueba exitosa.
- No se detectaron errores de ejecución durante las validaciones automatizadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b81d057fac832bbcc02873708e8cfa)