### PR TITLE
Añadir bloque "Experimentos" y reordenar acordeones de Música (móvil)

### DIFF
--- a/script.js
+++ b/script.js
@@ -343,9 +343,8 @@ movementToggleButton.addEventListener('click', () => {
 // Crear contenido de la ventana de música
 if (isMobile) {
   populateMobileMusicSections();
-} else {
-  populateInstrumentals();
 }
+populateInstrumentals();
 
 // Abrir ventana al hacer click en una zona
 zonesContainer.addEventListener('click', e => {
@@ -777,8 +776,9 @@ function populateMobileMusicSections() {
   container.innerHTML = '';
 
   const sections = [
-    { key: 'covers', title: 'Covers' },
-    { key: 'instrumentales', title: 'Instrumentales' }
+    { key: 'instrumentales', title: 'Instrumentales' },
+    { key: 'experimentos', title: 'Experimentos' },
+    { key: 'covers', title: 'Covers' }
   ];
 
   sections.forEach((section, index) => {
@@ -804,6 +804,13 @@ function populateMobileMusicSections() {
       content.appendChild(coversContainer);
     }
 
+    if (section.key === 'experimentos') {
+      const experimentsContainer = document.createElement('div');
+      experimentsContainer.className = 'mobile-experiments-container';
+      experimentsContainer.dataset.section = 'experiments-container';
+      content.appendChild(experimentsContainer);
+    }
+
     block.appendChild(summary);
     block.appendChild(content);
     container.appendChild(block);
@@ -811,7 +818,9 @@ function populateMobileMusicSections() {
 }
 
 function populateInstrumentals() {
-  const container = document.querySelector('#popup-instrumentales .popup-content');
+  const container = isMobile
+    ? document.querySelector('#popup-instrumentales .mobile-music-accordion__content[data-section="instrumentales"]')
+    : document.querySelector('#popup-instrumentales .popup-content');
   if (!container) return;
   instrumentals.forEach(inst => {
     const item = document.createElement('div');


### PR DESCRIPTION
### Motivation
- Añadir en la ventana emergente de `Música` para móvil un bloque desplegable adicional llamado `EXPERIMENTOS` con la misma UX de acordeón que `Instrumentales` y `Covers`.
- Mostrar los bloques en el orden solicitado de arriba a abajo: `Instrumentales`, `Experimentos`, `Covers`.
- Asegurar que la lista de `instrumentales` se cargue dentro del bloque `Instrumentales` en la vista móvil.

### Description
- Actualiza `populateMobileMusicSections()` para renderizar tres secciones en el orden `instrumentales`, `experimentos`, `covers` y marca cada bloque con `data-section` correspondiente.
- Añade un contenedor específico para la sección `experimentos` llamado `.mobile-experiments-container` y lo inserta en el acordeón móvil cuando corresponde.
- Modifica `populateInstrumentals()` para apuntar, en móvil, al contenedor `#popup-instrumentales .mobile-music-accordion__content[data-section="instrumentales"]` en lugar del contenedor global, y mantiene la carga para escritorio.
- Llama a `populateInstrumentals()` después de construir los acordeones para que los instrumentales queden insertados dentro del bloque `Instrumentales` en móvil; los cambios están en `script.js`.

### Testing
- Ejecutado `node --check script.js` y no se reportaron errores (comprobación de sintaxis pasó).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfb7a2ed0c832ba0f172784bb24efe)