### PR TITLE
Rediseño de tarjeta de instrumentales móvil: etiqueta y barra de progreso

### DIFF
--- a/script.js
+++ b/script.js
@@ -769,6 +769,17 @@ window.addEventListener('popstate', e => {
 // =============================
 let currentAudio = null;
 
+function resetAudioItemState(playerState) {
+  if (!playerState) return;
+  const { audio, button, progressFill } = playerState;
+  audio.pause();
+  audio.currentTime = 0;
+  button.textContent = '▶';
+  if (progressFill) {
+    progressFill.style.width = '0%';
+  }
+}
+
 function populateMobileMusicSections() {
   const container = document.querySelector('#popup-instrumentales .popup-content');
   if (!container) return;
@@ -827,42 +838,72 @@ function populateInstrumentals() {
     const item = document.createElement('div');
     item.className = 'audio-item';
 
+    const topRow = document.createElement('div');
+    topRow.className = 'audio-item__top-row';
+
     const title = document.createElement('span');
+    title.className = 'audio-item__title';
     title.textContent = inst.name;
 
+    const tag = document.createElement('span');
+    tag.className = 'audio-item__tag';
+    tag.textContent = 'HipHop';
+
+    const controlsRow = document.createElement('div');
+    controlsRow.className = 'audio-item__controls-row';
+
     const btn = document.createElement('button');
+    btn.className = 'audio-item__play-btn';
     btn.textContent = '▶';
+    btn.setAttribute('aria-label', `Reproducir instrumental ${inst.name}`);
+
+    const progress = document.createElement('div');
+    progress.className = 'audio-item__progress';
+
+    const progressFill = document.createElement('div');
+    progressFill.className = 'audio-item__progress-fill';
+    progress.appendChild(progressFill);
 
     const audio = new Audio(inst.src);
+    audio.preload = 'metadata';
+
+    const updateProgress = () => {
+      if (!audio.duration) return;
+      const pct = Math.max(0, Math.min((audio.currentTime / audio.duration) * 100, 100));
+      progressFill.style.width = `${pct}%`;
+    };
 
     btn.addEventListener('click', () => {
       if (currentAudio && currentAudio.audio !== audio) {
-        currentAudio.audio.pause();
-        currentAudio.audio.currentTime = 0;
-        currentAudio.button.textContent = '▶';
+        resetAudioItemState(currentAudio);
       }
 
       if (audio.paused) {
         audio.play();
         btn.textContent = '⏸';
-        currentAudio = { audio, button: btn };
+        currentAudio = { audio, button: btn, progressFill };
       } else {
-        audio.pause();
-        audio.currentTime = 0;
-        btn.textContent = '▶';
+        resetAudioItemState({ audio, button: btn, progressFill });
         currentAudio = null;
       }
     });
 
+    audio.addEventListener('timeupdate', updateProgress);
+
     audio.addEventListener('ended', () => {
       btn.textContent = '▶';
+      progressFill.style.width = '100%';
       if (currentAudio && currentAudio.audio === audio) {
         currentAudio = null;
       }
     });
 
-    item.appendChild(title);
-    item.appendChild(btn);
+    topRow.appendChild(title);
+    topRow.appendChild(tag);
+    controlsRow.appendChild(btn);
+    controlsRow.appendChild(progress);
+    item.appendChild(topRow);
+    item.appendChild(controlsRow);
     container.appendChild(item);
   });
 }

--- a/style.css
+++ b/style.css
@@ -680,23 +680,76 @@ body.popup-open #mobile-game {
 /* Listado de instrumentales */
 .audio-item {
   width: 90%;
-  height: 40px;
   margin: 8px auto;
   background: #000;
   color: #fff;
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 10px;
+  flex-direction: column;
+  gap: 10px;
+  padding: 10px;
   box-sizing: border-box;
+  border: 2px solid rgba(255, 255, 255, 0.18);
 }
 
-.audio-item button {
+.audio-item__top-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: start;
+}
+
+.audio-item__title {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  line-height: 1.3;
+}
+
+.audio-item__tag {
+  justify-self: end;
+  align-self: start;
+  padding: 2px 8px;
+  font-size: 10px;
+  border: 1px solid currentColor;
+  border-radius: 99px;
+  white-space: nowrap;
+}
+
+.audio-item__controls-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+}
+
+.audio-item__play-btn {
   background: none;
   border: none;
   color: inherit;
   cursor: pointer;
   font-size: var(--audio-button-font-size);
+  line-height: 1;
+  padding: 0;
+}
+
+.audio-item__progress {
+  position: relative;
+  width: 100%;
+  height: 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  background: repeating-linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.1) 0 4px,
+    rgba(255, 255, 255, 0.03) 4px 8px
+  );
+  overflow: hidden;
+}
+
+.audio-item__progress-fill {
+  width: 0%;
+  height: 100%;
+  background: linear-gradient(90deg, #b56aff, #f7a6ff);
+  transition: width 0.12s linear;
 }
 
 body.light-mode .audio-item {
@@ -704,8 +757,17 @@ body.light-mode .audio-item {
   color: #000;
 }
 
-body.light-mode .audio-item button {
+body.light-mode .audio-item__play-btn {
   color: inherit;
+}
+
+body.light-mode .audio-item__progress {
+  border-color: rgba(0, 0, 0, 0.35);
+  background: repeating-linear-gradient(
+    90deg,
+    rgba(0, 0, 0, 0.09) 0 4px,
+    rgba(0, 0, 0, 0.03) 4px 8px
+  );
 }
 
 /* Encabezado móvil oculto en la versión web */


### PR DESCRIPTION
### Motivation
- Mejorar la presentación de cada instrumental en la ventana móvil para que tenga dos filas: título a la izquierda y una etiqueta "HipHop" a la derecha en la fila superior, y controles (play) + barra de progreso en la fila inferior. 
- Evitar solapes con títulos largos permitiendo salto a varias líneas y proporcionar una representación visual del progreso de reproducción.

### Description
- Reestructura DOM de cada elemento en `populateInstrumentals()` para crear una `audio-item` con `audio-item__top-row` (título + `HipHop`) y `audio-item__controls-row` (botón play y barra de progreso), y añade atributos accesibles (`aria-label`).
- Añade manejo de estado con `resetAudioItemState()` y mejora la lógica de reproducción para reiniciar botón y progreso al cambiar/pausar pista y para mantener un único audio activo (`currentAudio`).
- Implementa barra de progreso visual con elementos `.audio-item__progress` y `.audio-item__progress-fill` actualizados desde el evento `timeupdate`, y añade estilos CSS (grid, wrapping, modo claro/oscuro) para evitar solapamientos y asegurar que títulos largos ocupen varias líneas sin cortar la etiqueta.

### Testing
- Se ejecutó `node --check script.js` y la verificación de sintaxis devolvió éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfbebbce54832b8ff2a6becfcc1cee)