### PR TITLE
Habilita seek interactivo en timeline de instrumentales móvil

### DIFF
--- a/script.js
+++ b/script.js
@@ -780,6 +780,48 @@ function resetAudioItemState(playerState) {
   }
 }
 
+function seekAudioFromProgress(progressElement, audio, clientX) {
+  const rect = progressElement.getBoundingClientRect();
+  if (!rect.width || !audio.duration) return;
+
+  const ratio = Math.max(0, Math.min((clientX - rect.left) / rect.width, 1));
+  audio.currentTime = ratio * audio.duration;
+}
+
+function bindProgressSeek(progressElement, audio) {
+  if (!progressElement || !audio) return;
+
+  let isPointerSeeking = false;
+
+  const handleSeek = clientX => {
+    seekAudioFromProgress(progressElement, audio, clientX);
+  };
+
+  progressElement.addEventListener('click', event => {
+    handleSeek(event.clientX);
+  });
+
+  progressElement.addEventListener('pointerdown', event => {
+    isPointerSeeking = true;
+    progressElement.setPointerCapture?.(event.pointerId);
+    handleSeek(event.clientX);
+  });
+
+  progressElement.addEventListener('pointermove', event => {
+    if (!isPointerSeeking) return;
+    handleSeek(event.clientX);
+  });
+
+  const stopSeeking = event => {
+    if (!isPointerSeeking) return;
+    isPointerSeeking = false;
+    progressElement.releasePointerCapture?.(event.pointerId);
+  };
+
+  progressElement.addEventListener('pointerup', stopSeeking);
+  progressElement.addEventListener('pointercancel', stopSeeking);
+}
+
 function populateMobileMusicSections() {
   const container = document.querySelector('#popup-instrumentales .popup-content');
   if (!container) return;
@@ -889,6 +931,7 @@ function populateInstrumentals() {
     });
 
     audio.addEventListener('timeupdate', updateProgress);
+    bindProgressSeek(progress, audio);
 
     audio.addEventListener('ended', () => {
       btn.textContent = '▶';

--- a/style.css
+++ b/style.css
@@ -735,6 +735,8 @@ body.popup-open #mobile-game {
   position: relative;
   width: 100%;
   height: 18px;
+  cursor: pointer;
+  touch-action: none;
   border-radius: 999px;
   border: 1px solid rgba(255, 255, 255, 0.45);
   background: repeating-linear-gradient(


### PR DESCRIPTION
### Motivation
- Mejorar la experiencia móvil permitiendo que la línea de tiempo (barra/onda) de cada instrumental sea interactiva y permita adelantar y atrasar la reproducción táctilmente o con clic.

### Description
- Añadí la función `seekAudioFromProgress` que calcula la posición relativa del `clientX` sobre la barra y ajusta `audio.currentTime` en consecuencia.
- Implementé `bindProgressSeek` que habilita interacción por `click` y búsqueda continua por puntero usando `pointerdown`, `pointermove`, `pointerup` y `pointercancel`.
- Conecté la lógica a cada item de instrumental llamando a `bindProgressSeek(progress, audio)` cuando se crean los elementos en `populateInstrumentals`.
- Actualicé estilos en `style.css` para la barra de progreso agregando `cursor: pointer` y `touch-action: none` para mejorar la respuesta táctil.

### Testing
- Ejecuté `node --check script.js` y la verificación de sintaxis pasó correctamente.
- Se comprobó que los cambios se aplican en los archivos modificados `script.js` y `style.css` sin errores de ejecución detectados por la verificación previa.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfc06ea91c832b87fdfc2d1cc5044e)