### PR TITLE
Añade texto introductorio al popup de contacto en móvil

### DIFF
--- a/config.js
+++ b/config.js
@@ -170,6 +170,13 @@ export const zones = [
       title: 'Contacto',
       content: `
         <div class="contact-popup">
+          <p class="contact-mobile-intro">
+            Si eres un artista o creativo en busca de:<br><br>
+            Instrumentales personalizadas · Catálogo de instrumentales · Producción musical personalizada<br>
+            Grabación en home studio · Grabación en estudio profesional · Desarrollo de concepto creativo<br><br>
+            Estaré encantado de ayudarte a dar forma a tu proyecto :)<br><br>
+            Desliza un poco hacia abajo y hablemos:
+          </p>
           <div class="social-column">
             <p class="column-title">Mis redes:</p>
             <a class="contact-social-link" href="https://www.youtube.com/@alonelndlm1312" target="_blank">

--- a/style.css
+++ b/style.css
@@ -438,6 +438,10 @@ body.popup-open #mobile-game {
   align-items: stretch;
 }
 
+.contact-mobile-intro {
+  display: none;
+}
+
 .contact-popup::before {
   content: "";
   position: absolute;
@@ -1424,6 +1428,13 @@ body.light-mode .audio-item__progress {
   .contact-popup {
     flex-direction: column;
     align-items: center;
+  }
+
+  .contact-mobile-intro {
+    display: block;
+    margin: 0 0 12px;
+    line-height: 1.45;
+    text-align: left;
   }
 
   .contact-popup::before {


### PR DESCRIPTION
### Motivation
- Añadir un texto introductorio al inicio de la ventana emergente de la sección `Contacto` en la versión móvil, respetando saltos de línea para conservar el formato solicitado.
- Mostrar ese texto solo en móviles para no alterar la versión de escritorio.

### Description
- Inserta un párrafo HTML con la clase `contact-mobile-intro` al inicio del contenido del popup `Contacto` en `config.js` para incluir el texto exacto solicitado con `br` para los saltos de línea.
- Añade reglas CSS en `style.css` que ocultan `.contact-mobile-intro` por defecto y la muestran con `display: block`, `margin`, `line-height` y `text-align: left` dentro del bloque de estilos para el breakpoint móvil.
- Los archivos modificados son `config.js` y `style.css`.

### Testing
- Ejecuté `git diff` para revisar los cambios en `config.js` y `style.css`, y la diff refleja la inserción del párrafo y las reglas CSS (resultado: OK).
- Ejecuté `git commit -m "Añade intro móvil al popup de contacto"` y el commit se creó correctamente (resultado: OK).
- Verificación manual del diff para confirmar que los saltos de línea se mantienen mediante `<br>` y que el estilo está confinado al breakpoint móvil (resultado: OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfc2644cd0832b8fe8b3e499b5bf0c)