### PR TITLE
Ajusta listado móvil de contacto: tamaño reducido y colores por ítem

### DIFF
--- a/config.js
+++ b/config.js
@@ -172,8 +172,16 @@ export const zones = [
         <div class="contact-popup">
           <p class="contact-mobile-intro">
             Si eres un artista o creativo en busca de:<br><br>
-            Instrumentales personalizadas · Catálogo de instrumentales · Producción musical personalizada<br>
-            Grabación en home studio · Grabación en estudio profesional · Desarrollo de concepto creativo<br><br>
+          </p>
+          <ul class="contact-mobile-services">
+            <li>Instrumentales personalizadas</li>
+            <li>Catálogo de instrumentales</li>
+            <li>Producción musical personalizada</li>
+            <li>Grabación en home studio</li>
+            <li>Grabación en estudio profesional</li>
+            <li>Desarrollo de concepto creativo</li>
+          </ul>
+          <p class="contact-mobile-intro">
             Estaré encantado de ayudarte a dar forma a tu proyecto :)<br><br>
             Desliza un poco hacia abajo y hablemos:
           </p>

--- a/style.css
+++ b/style.css
@@ -442,6 +442,10 @@ body.popup-open #mobile-game {
   display: none;
 }
 
+.contact-mobile-services {
+  display: none;
+}
+
 .contact-popup::before {
   content: "";
   position: absolute;
@@ -1436,6 +1440,22 @@ body.light-mode .audio-item__progress {
     line-height: 1.45;
     text-align: left;
   }
+
+  .contact-mobile-services {
+    display: block;
+    margin: 0 0 14px;
+    padding-left: 18px;
+    font-size: 12px;
+    line-height: 1.35;
+    text-align: left;
+  }
+
+  .contact-mobile-services li:nth-child(1) { color: #ff7aa2; }
+  .contact-mobile-services li:nth-child(2) { color: #ffd166; }
+  .contact-mobile-services li:nth-child(3) { color: #7ef29a; }
+  .contact-mobile-services li:nth-child(4) { color: #7ad8ff; }
+  .contact-mobile-services li:nth-child(5) { color: #bba0ff; }
+  .contact-mobile-services li:nth-child(6) { color: #ff9b6b; }
 
   .contact-popup::before {
     display: none;


### PR DESCRIPTION
### Motivation
- Hacer que el bloque inicial de servicios en la ventana emergente de `Contacto` en móvil tenga letra más pequeña y permitir colorear cada elemento por separado.
- Convertir el texto corrido en una estructura semántica para poder aplicar estilos por elemento y mejorar accesibilidad.

### Description
- Reemplacé la línea de servicios en `popup.content` por una lista semántica `<ul class="contact-mobile-services">` con 6 `<li>` en `config.js`.
- Añadí reglas CSS para ocultar la lista fuera de móvil y mostrarla en móvil con `font-size: 12px`, espaciado reducido y alineado a la izquierda en `style.css`.
- Definí colores distintos para cada elemento de la lista usando selectores `:nth-child(1..6)` en `style.css`.

### Testing
- Ejecuté `node --check config.js` y la comprobación de sintaxis JavaScript finalizó correctamente.
- Ejecuté `node --check script.js` y la comprobación de sintaxis JavaScript finalizó correctamente.
- Verifiqué que los cambios no introducen errores de parseo en los archivos editados y que los estilos están añadidos en `style.css`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfc3c98b48832ba935a3b00fe1ac4a)