### PR TITLE
Make Trabajos popup songs horizontally scrollable on mobile (80% width rails)

### DIFF
--- a/config.js
+++ b/config.js
@@ -63,47 +63,49 @@ export const zones = [
           </div>
 
           <!-- Canciones del Álbum 1 -->
-          <div class="work-song">
-            <a class="thumb-link" href="https://youtu.be/gjnF2xA8EgU?si=-Lz4cv3UeemV82s7" target="_blank">
-              <img class="thumb" src="assets/MINI 2.jpg" alt="Canción 1">
-            </a>
-            <a class="title-link" href="https://youtu.be/gjnF2xA8EgU?si=-Lz4cv3UeemV82s7" target="_blank">1 Gama Ocre</a>
-          </div>
-          <div class="work-song">
-            <a class="thumb-link" href="https://youtu.be/olTjbh7295U?si=6XDtN3jbhnOMuLol" target="_blank">
-              <img class="thumb" src="assets/MINI 3.jpg" alt="Canción 2">
-            </a>
-            <a class="title-link" href="https://youtu.be/olTjbh7295U?si=6XDtN3jbhnOMuLol" target="_blank">2 Chicos Malos Buenos Tipos</a>
-          </div>
-          <div class="work-song">
-            <a class="thumb-link" href="https://youtu.be/w4X0c4Csqck?si=phNUqeIYaCTdfJEB" target="_blank">
-              <img class="thumb" src="assets/MINI 4.jpg" alt="Canción 2">
-            </a>
-            <a class="title-link" href="https://youtu.be/w4X0c4Csqck?si=phNUqeIYaCTdfJEB" target="_blank">3 Los Penúltimos Versos Que Te Escribo</a>
-          </div>
-          <div class="work-song">
-            <a class="thumb-link" href="https://youtu.be/iBjQlLn3eGI?si=11dlDPzwzun_HKG5" target="_blank">
-              <img class="thumb" src="assets/MINI 5.jpg" alt="Canción 2">
-            </a>
-            <a class="title-link" href="https://youtu.be/iBjQlLn3eGI?si=11dlDPzwzun_HKG5" target="_blank">4 El Niño y Su Fe</a>
-          </div>
-          <div class="work-song">
-            <a class="thumb-link" href="https://youtu.be/E5ZnLgfJucQ?si=sVSPpSJ5IDL6jNVH" target="_blank">
-              <img class="thumb" src="assets/MINI 6.jpg" alt="Canción 2">
-            </a>
-            <a class="title-link" href="https://youtu.be/E5ZnLgfJucQ?si=sVSPpSJ5IDL6jNVH" target="_blank">5 Mi Negra Tomasa</a>
-          </div>
-          <div class="work-song">
-            <a class="thumb-link" href="https://youtu.be/N-r1HKcgNl8?si=Sl-_nix8Xwfa8e34" target="_blank">
-              <img class="thumb" src="assets/MINI 7.jpg" alt="Canción 2">
-            </a>
-            <a class="title-link" href="https://youtu.be/N-r1HKcgNl8?si=Sl-_nix8Xwfa8e34" target="_blank">6 Continental 67´</a>
-          </div>
-          <div class="work-song">
-            <a class="thumb-link" href="https://youtu.be/9To2SQiQXKE?si=Nqrg5c2J_sX0-M4l" target="_blank">
-              <img class="thumb" src="assets/MINI 8.jpg" alt="Canción 2">
-            </a>
-            <a class="title-link" href="https://youtu.be/9To2SQiQXKE?si=Nqrg5c2J_sX0-M4l" target="_blank">7 Xyla</a>
+          <div class="work-songs-row">
+            <div class="work-song">
+              <a class="thumb-link" href="https://youtu.be/gjnF2xA8EgU?si=-Lz4cv3UeemV82s7" target="_blank">
+                <img class="thumb" src="assets/MINI 2.jpg" alt="Canción 1">
+              </a>
+              <a class="title-link" href="https://youtu.be/gjnF2xA8EgU?si=-Lz4cv3UeemV82s7" target="_blank">1 Gama Ocre</a>
+            </div>
+            <div class="work-song">
+              <a class="thumb-link" href="https://youtu.be/olTjbh7295U?si=6XDtN3jbhnOMuLol" target="_blank">
+                <img class="thumb" src="assets/MINI 3.jpg" alt="Canción 2">
+              </a>
+              <a class="title-link" href="https://youtu.be/olTjbh7295U?si=6XDtN3jbhnOMuLol" target="_blank">2 Chicos Malos Buenos Tipos</a>
+            </div>
+            <div class="work-song">
+              <a class="thumb-link" href="https://youtu.be/w4X0c4Csqck?si=phNUqeIYaCTdfJEB" target="_blank">
+                <img class="thumb" src="assets/MINI 4.jpg" alt="Canción 2">
+              </a>
+              <a class="title-link" href="https://youtu.be/w4X0c4Csqck?si=phNUqeIYaCTdfJEB" target="_blank">3 Los Penúltimos Versos Que Te Escribo</a>
+            </div>
+            <div class="work-song">
+              <a class="thumb-link" href="https://youtu.be/iBjQlLn3eGI?si=11dlDPzwzun_HKG5" target="_blank">
+                <img class="thumb" src="assets/MINI 5.jpg" alt="Canción 2">
+              </a>
+              <a class="title-link" href="https://youtu.be/iBjQlLn3eGI?si=11dlDPzwzun_HKG5" target="_blank">4 El Niño y Su Fe</a>
+            </div>
+            <div class="work-song">
+              <a class="thumb-link" href="https://youtu.be/E5ZnLgfJucQ?si=sVSPpSJ5IDL6jNVH" target="_blank">
+                <img class="thumb" src="assets/MINI 6.jpg" alt="Canción 2">
+              </a>
+              <a class="title-link" href="https://youtu.be/E5ZnLgfJucQ?si=sVSPpSJ5IDL6jNVH" target="_blank">5 Mi Negra Tomasa</a>
+            </div>
+            <div class="work-song">
+              <a class="thumb-link" href="https://youtu.be/N-r1HKcgNl8?si=Sl-_nix8Xwfa8e34" target="_blank">
+                <img class="thumb" src="assets/MINI 7.jpg" alt="Canción 2">
+              </a>
+              <a class="title-link" href="https://youtu.be/N-r1HKcgNl8?si=Sl-_nix8Xwfa8e34" target="_blank">6 Continental 67´</a>
+            </div>
+            <div class="work-song">
+              <a class="thumb-link" href="https://youtu.be/9To2SQiQXKE?si=Nqrg5c2J_sX0-M4l" target="_blank">
+                <img class="thumb" src="assets/MINI 8.jpg" alt="Canción 2">
+              </a>
+              <a class="title-link" href="https://youtu.be/9To2SQiQXKE?si=Nqrg5c2J_sX0-M4l" target="_blank">7 Xyla</a>
+            </div>
           </div>
 
           <!-- Álbum 2 -->
@@ -123,35 +125,37 @@ export const zones = [
           </div>
 
           <!-- Canciones del Álbum 2 -->
-          <div class="work-song">
-            <a class="thumb-link" href="https://youtu.be/r7v66L14CIY?si=i29TWJnDchiaF02K" target="_blank">
-              <img class="thumb" src="assets/TDB5.jpg" alt="Canción A">
-            </a>
-            <a class="title-link" href="https://youtu.be/r7v66L14CIY?si=i29TWJnDchiaF02K" target="_blank">1 El Miajón</a>
-          </div>
-          <div class="work-song">
-            <a class="thumb-link" href="https://youtu.be/qrz6GHOQeWo?si=G3NDKIrxeIGsKGWG" target="_blank">
-              <img class="thumb" src="assets/TDB1.jpg" alt="Canción B">
-            </a>
-            <a class="title-link" href="https://youtu.be/qrz6GHOQeWo?si=G3NDKIrxeIGsKGWG" target="_blank">2 LXXL</a>
-          </div>
-          <div class="work-song">
-            <a class="thumb-link" href="https://youtu.be/VoGZL0BbisA?si=O8v8NPwVlMLQr_QL" target="_blank">
-              <img class="thumb" src="assets/TDB2.webp" alt="Canción A">
-            </a>
-            <a class="title-link" href="https://youtu.be/VoGZL0BbisA?si=O8v8NPwVlMLQr_QL" target="_blank">3 MID00´S</a>
-          </div>
-          <div class="work-song">
-            <a class="thumb-link" href="https://youtu.be/TCTaVd1pkNU?si=FIcTLrw6MaOrvbLk" target="_blank">
-              <img class="thumb" src="assets/TDB3.webp" alt="Canción A">
-            </a>
-            <a class="title-link" href="https://youtu.be/TCTaVd1pkNU?si=FIcTLrw6MaOrvbLk" target="_blank">4 DETROIT 89´</a>
-          </div>
-          <div class="work-song">
-            <a class="thumb-link" href="https://youtu.be/1bG2_86Cqzk?si=KlASDkXCWNGy3NUz" target="_blank">
-              <img class="thumb" src="assets/TDB4.webp" alt="Canción A">
-            </a>
-            <a class="title-link" href="https://youtu.be/1bG2_86Cqzk?si=KlASDkXCWNGy3NUz" target="_blank">5 WUTW</a>
+          <div class="work-songs-row">
+            <div class="work-song">
+              <a class="thumb-link" href="https://youtu.be/r7v66L14CIY?si=i29TWJnDchiaF02K" target="_blank">
+                <img class="thumb" src="assets/TDB5.jpg" alt="Canción A">
+              </a>
+              <a class="title-link" href="https://youtu.be/r7v66L14CIY?si=i29TWJnDchiaF02K" target="_blank">1 El Miajón</a>
+            </div>
+            <div class="work-song">
+              <a class="thumb-link" href="https://youtu.be/qrz6GHOQeWo?si=G3NDKIrxeIGsKGWG" target="_blank">
+                <img class="thumb" src="assets/TDB1.jpg" alt="Canción B">
+              </a>
+              <a class="title-link" href="https://youtu.be/qrz6GHOQeWo?si=G3NDKIrxeIGsKGWG" target="_blank">2 LXXL</a>
+            </div>
+            <div class="work-song">
+              <a class="thumb-link" href="https://youtu.be/VoGZL0BbisA?si=O8v8NPwVlMLQr_QL" target="_blank">
+                <img class="thumb" src="assets/TDB2.webp" alt="Canción A">
+              </a>
+              <a class="title-link" href="https://youtu.be/VoGZL0BbisA?si=O8v8NPwVlMLQr_QL" target="_blank">3 MID00´S</a>
+            </div>
+            <div class="work-song">
+              <a class="thumb-link" href="https://youtu.be/TCTaVd1pkNU?si=FIcTLrw6MaOrvbLk" target="_blank">
+                <img class="thumb" src="assets/TDB3.webp" alt="Canción A">
+              </a>
+              <a class="title-link" href="https://youtu.be/TCTaVd1pkNU?si=FIcTLrw6MaOrvbLk" target="_blank">4 DETROIT 89´</a>
+            </div>
+            <div class="work-song">
+              <a class="thumb-link" href="https://youtu.be/1bG2_86Cqzk?si=KlASDkXCWNGy3NUz" target="_blank">
+                <img class="thumb" src="assets/TDB4.webp" alt="Canción A">
+              </a>
+              <a class="title-link" href="https://youtu.be/1bG2_86Cqzk?si=KlASDkXCWNGy3NUz" target="_blank">5 WUTW</a>
+            </div>
           </div>
 
           </div>

--- a/style.css
+++ b/style.css
@@ -670,6 +670,13 @@ body.popup-open #mobile-game {
   box-sizing: border-box;
 }
 
+.work-songs-row {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+}
+
 .work-song .thumb {
   width: 120px;
   aspect-ratio: 16 / 9;
@@ -1514,6 +1521,24 @@ body.light-mode .audio-item__progress {
     padding-left: 0;
   }
 
+  .work-songs-row {
+    width: 80%;
+    margin: 0 auto 12px;
+    display: flex;
+    flex-direction: row;
+    gap: 12px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scroll-snap-type: x proximity;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .work-songs-row .work-song {
+    flex: 0 0 160px;
+    width: 160px;
+    scroll-snap-align: start;
+  }
+
   /* Solo para álbumes: título arriba, miniatura debajo y descripción después */
   .work-album {
     display: grid;
@@ -1560,6 +1585,10 @@ body.light-mode .audio-item__progress {
 
   .work-song .thumb {
     width: min(85%, 220px);
+  }
+
+  .work-songs-row .work-song .thumb {
+    width: 100%;
   }
 
 }


### PR DESCRIPTION
### Motivation
- Improve mobile UX in the `Trabajos` popup by changing the second-level items (songs) from a vertical list to a horizontally scrollable rail that is easier to scan by swipe. 
- Keep desktop behavior unchanged while preserving the album → songs hierarchy in the popup HTML.

### Description
- Wrapped each album's song items in a new container in `config.js`: each group of song `.work-song` elements is now inside a `<div class="work-songs-row">` per album. 
- Added base styles and responsive rules in `style.css` for `.work-songs-row` so it defaults to vertical stacking on desktop and becomes a horizontal, swipeable rail on mobile, occupying `80%` of the viewport width. 
- Mobile-specific CSS sets `display: flex; flex-direction: row; overflow-x: auto; scroll-snap-type: x proximity; -webkit-overflow-scrolling: touch;` and ensures each `.work-song` behaves like a fixed-width card (`flex: 0 0 160px`) with thumbnails filling the card. 
- No JavaScript logic changes were required; the change is purely HTML/CSS structure and styles.

### Testing
- Ran `node --check config.js` and the file checked without syntax errors (success). 
- Ran `node --check script.js` and the file checked without syntax errors (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfe148a53c832ba751d070725ee9ae)