### PR TITLE
Mover descripciones de álbum en móvil debajo de las canciones (popup Trabajos)

### DIFF
--- a/script.js
+++ b/script.js
@@ -228,6 +228,10 @@ zones.forEach(zone => {
   popupsContainer.appendChild(popup);
   popups[zone.id] = popup; // guardar referencia
 
+  if (isMobile && zone.id === 'trabajos') {
+    moveAlbumDescriptionsBelowSongs(popup);
+  }
+
   // Asegurar que las ventanas se oculten tras la animación de cierre
   popup.addEventListener('transitionend', () => {
     if (!popup.classList.contains('visible')) {
@@ -237,6 +241,22 @@ zones.forEach(zone => {
     }
   });
 });
+
+function moveAlbumDescriptionsBelowSongs(popup) {
+  const gallery = popup.querySelector('.trabajos-gallery');
+  if (!gallery) return;
+
+  const albums = gallery.querySelectorAll('.work-album');
+  albums.forEach(album => {
+    const description = album.querySelector('.album-description');
+    const songsRow = album.nextElementSibling;
+
+    if (!description || !songsRow || !songsRow.classList.contains('work-songs-row')) return;
+
+    description.classList.add('album-description--after-songs');
+    songsRow.insertAdjacentElement('afterend', description);
+  });
+}
 
 function hasActivePopup(popup) {
   return popup && !popup.classList.contains('hidden');

--- a/style.css
+++ b/style.css
@@ -1539,13 +1539,12 @@ body.light-mode .audio-item__progress {
     scroll-snap-align: start;
   }
 
-  /* Solo para álbumes: título arriba, miniatura debajo y descripción después */
+  /* Solo para álbumes: título arriba y miniatura debajo */
   .work-album {
     display: grid;
     grid-template-areas:
       'album-title'
-      'album-thumb'
-      'album-description';
+      'album-thumb';
     row-gap: 0;
   }
 
@@ -1562,15 +1561,17 @@ body.light-mode .audio-item__progress {
     margin-bottom: 8px;
   }
 
-  .work-album > .info .album-description {
-    grid-area: album-description;
-  }
-
   .work-album .info,
   .work-song .info,
   .album-description p {
     width: 100%;
     text-align: left;
+  }
+
+  .album-description--after-songs {
+    width: 90%;
+    margin: 0 auto 16px;
+    display: block;
   }
  
   .work-album .thumb,


### PR DESCRIPTION
### Motivation
- En la versión móvil del popup `Trabajos` se requiere que la descripción de cada álbum aparezca después de la fila de canciones en lugar de debajo de la miniatura para mejorar la lectura y el flujo de contenido.

### Description
- Añadida la función `moveAlbumDescriptionsBelowSongs` en `script.js` que, en móviles y solo para `zone.id === 'trabajos'`, mueve cada `.album-description` tras su correspondiente `.work-songs-row` cuando se genera el popup. 
- Modificados `script.js` y `style.css` para aplicar el cambio solo en móvil y mantener el comportamiento de escritorio sin cambios. 
- Eliminada la colocación por grid de la descripción dentro de `.work-album` en `style.css` y añadida la clase `.album-description--after-songs` para estilizar las descripciones reposicionadas.

### Testing
- Ejecutado `node --check script.js` y la comprobación de sintaxis de `script.js` pasó correctamente. 
- Se verificó que los archivos modificados son `script.js` y `style.css` y que no hay errores de sintaxis reportados durante las comprobaciones automáticas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfe7de8ecc832b921fef22f012ad45)