### PR TITLE
Centrar títulos y miniaturas de álbumes en el popup móvil de Trabajos

### DIFF
--- a/style.css
+++ b/style.css
@@ -1550,6 +1550,7 @@ body.light-mode .audio-item__progress {
 
   .work-album > .album-link {
     grid-area: album-thumb;
+    justify-self: center;
   }
 
   .work-album > .info {
@@ -1559,6 +1560,7 @@ body.light-mode .audio-item__progress {
   .work-album > .info h3 {
     grid-area: album-title;
     margin-bottom: 8px;
+    text-align: center;
   }
 
   .work-album .info,


### PR DESCRIPTION
### Motivation
- Mejorar la presentación en móviles del popup `Trabajos` centrando la miniatura principal y el título de cada álbum para una lectura y apariencia más coherente.

### Description
- En `style.css` añadí `justify-self: center` a `.work-album > .album-link` y `text-align: center` a `.work-album > .info h3` para centrar la miniatura y el `h3` del álbum en la vista móvil; no se tocaron archivos JavaScript.

### Testing
- Verifiqué los cambios con `git diff -- style.css`, `git status --short` y realicé el `git commit` con éxito; revisión de diff completada y commit creado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfea568dd0832baff2978095882390)