### PR TITLE
Fix mobile Trabajos album thumbnail centering and size

### DIFF
--- a/style.css
+++ b/style.css
@@ -1551,6 +1551,9 @@ body.light-mode .audio-item__progress {
   .work-album > .album-link {
     grid-area: album-thumb;
     justify-self: center;
+    width: min(94%, 390px);
+    margin: 0 auto;
+    display: block;
   }
 
   .work-album > .info {
@@ -1584,7 +1587,8 @@ body.light-mode .audio-item__progress {
   }
 
   .work-album .thumb {
-    width: min(100%, 350px);
+    width: 100%;
+    margin: 0 auto 12px;
   }
 
   .work-song .thumb {


### PR DESCRIPTION
### Motivation
- The album thumbnail in the mobile `Trabajos` popup was visually off-center and a bit small because the link container lacked an explicit block layout and width on mobile, causing inherited inline alignment to misplace the image.

### Description
- Updated `style.css` to make `.work-album > .album-link` a block-level element with `width: min(94%, 390px)` and `margin: 0 auto` so the thumbnail container is explicitly centered.
- Adjusted `.work-album .thumb` to fill the new container (`width: 100%`) and added a small bottom margin so the album image appears slightly larger and centered on mobile.

### Testing
- Ran `git diff --check` to validate the patch and it completed without issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfec2af6f4832b905de7e0a3081171)