### PR TITLE
Agregar tarjetas de álbum en el popup móvil de Trabajos

### DIFF
--- a/script.js
+++ b/script.js
@@ -229,7 +229,7 @@ zones.forEach(zone => {
   popups[zone.id] = popup; // guardar referencia
 
   if (isMobile && zone.id === 'trabajos') {
-    moveAlbumDescriptionsBelowSongs(popup);
+    organizeTrabajosAlbumsForMobile(popup);
   }
 
   // Asegurar que las ventanas se oculten tras la animación de cierre
@@ -242,19 +242,37 @@ zones.forEach(zone => {
   });
 });
 
-function moveAlbumDescriptionsBelowSongs(popup) {
+function organizeTrabajosAlbumsForMobile(popup) {
   const gallery = popup.querySelector('.trabajos-gallery');
-  if (!gallery) return;
+  if (!gallery || gallery.querySelector('.work-album-card')) return;
 
-  const albums = gallery.querySelectorAll('.work-album');
+  const albums = Array.from(gallery.querySelectorAll('.work-album'));
   albums.forEach(album => {
     const description = album.querySelector('.album-description');
     const songsRow = album.nextElementSibling;
 
-    if (!description || !songsRow || !songsRow.classList.contains('work-songs-row')) return;
+    if (songsRow && songsRow.classList.contains('work-songs-row')) {
+      if (description) {
+        description.classList.add('album-description--after-songs');
+        songsRow.insertAdjacentElement('afterend', description);
+      }
+    }
 
-    description.classList.add('album-description--after-songs');
-    songsRow.insertAdjacentElement('afterend', description);
+    const card = document.createElement('article');
+    card.className = 'work-album-card';
+    if (album.classList.contains('album-divider')) {
+      card.classList.add('work-album-card--divider');
+      album.classList.remove('album-divider');
+    }
+
+    gallery.insertBefore(card, album);
+    card.appendChild(album);
+    if (songsRow && songsRow.classList.contains('work-songs-row')) {
+      card.appendChild(songsRow);
+    }
+    if (description && description.classList.contains('album-description--after-songs')) {
+      card.appendChild(description);
+    }
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -1505,6 +1505,19 @@ body.light-mode .audio-item__progress {
     font-size: 13px;
   }
 
+  .work-album-card {
+    width: 92%;
+    margin: 0 auto 18px;
+    padding: 12px 10px 14px;
+    border: 4px solid #000;
+    background: rgba(255, 255, 255, 0.22);
+    box-sizing: border-box;
+  }
+
+  .work-album-card--divider {
+    margin-top: 24px;
+  }
+
   .trabajos-gallery .thumb {
     display: block;
     margin: 0;
@@ -1522,8 +1535,8 @@ body.light-mode .audio-item__progress {
   }
 
   .work-songs-row {
-    width: 90%;
-    margin: 0 auto 12px;
+    width: 100%;
+    margin: 0 0 12px;
     display: flex;
     flex-direction: row;
     gap: 12px;
@@ -1574,8 +1587,8 @@ body.light-mode .audio-item__progress {
   }
 
   .album-description--after-songs {
-    width: 90%;
-    margin: 0 auto 16px;
+    width: 100%;
+    margin: 0;
     display: block;
   }
  


### PR DESCRIPTION
### Motivation
- Mejorar la presentación móvil de la sección `Trabajos` agrupando cada álbum en una «tarjeta» que contenga título, miniatura, carrusel de canciones y descripción dentro de la ventana emergente.

### Description
- Reemplacé la función de reorganización móvil por `organizeTrabajosAlbumsForMobile(popup)` en `script.js` para envolver cada `.work-album` en un contenedor `article.work-album-card` y agrupar también su `.work-songs-row` y `.album-description` cuando correspondan.
- Añadí una protección para evitar volver a procesar la galería si ya existe una `.work-album-card` y mantuve el manejo de `album-divider` trasladando esa clase al nuevo contenedor.
- Agregué estilos en `style.css` para `.work-album-card` y ajusté reglas móviles de `.work-songs-row` y `.album-description--after-songs` para que el contenido quede correctamente contenido y con borde/fondo/padding coherentes en pantallas pequeñas.
- Cambié la llamada en la inicialización de popups para usar la nueva función cuando `zone.id === 'trabajos'` en modo móvil.

### Testing
- Ejecuté `node --check script.js` y no se reportaron errores de sintaxis.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bff3b440a4832b83a6657d1a05e71e)