### PR TITLE
Tarjetas colapsables en popup móvil "Trabajos"

### DIFF
--- a/script.js
+++ b/script.js
@@ -267,11 +267,38 @@ function organizeTrabajosAlbumsForMobile(popup) {
 
     gallery.insertBefore(card, album);
     card.appendChild(album);
+    const collapsibleContent = document.createElement('div');
+    collapsibleContent.className = 'work-album-collapsible';
+
     if (songsRow && songsRow.classList.contains('work-songs-row')) {
-      card.appendChild(songsRow);
+      collapsibleContent.appendChild(songsRow);
     }
     if (description && description.classList.contains('album-description--after-songs')) {
-      card.appendChild(description);
+      collapsibleContent.appendChild(description);
+    }
+
+    if (collapsibleContent.childElementCount > 0) {
+      const toggle = document.createElement('button');
+      toggle.type = 'button';
+      toggle.className = 'work-album-toggle';
+      toggle.setAttribute('aria-expanded', 'false');
+      toggle.setAttribute('aria-label', 'Ampliar tarjeta del álbum');
+      toggle.innerHTML = '<span class="work-album-toggle__arrow" aria-hidden="true">⌄</span>';
+
+      card.classList.add('is-collapsed');
+      collapsibleContent.hidden = true;
+      card.appendChild(toggle);
+      card.appendChild(collapsibleContent);
+
+      toggle.addEventListener('click', () => {
+        const isCollapsed = card.classList.toggle('is-collapsed');
+        const expanded = !isCollapsed;
+        collapsibleContent.hidden = isCollapsed;
+        toggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+        toggle.setAttribute('aria-label', expanded ? 'Contraer tarjeta del álbum' : 'Ampliar tarjeta del álbum');
+      });
+    } else {
+      card.appendChild(collapsibleContent);
     }
   });
 }

--- a/style.css
+++ b/style.css
@@ -1514,6 +1514,34 @@ body.light-mode .audio-item__progress {
     box-sizing: border-box;
   }
 
+  .work-album-collapsible {
+    width: 100%;
+  }
+
+  .work-album-toggle {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    margin: 6px auto 0;
+    padding: 4px 0 0;
+    border: none;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+  }
+
+  .work-album-toggle__arrow {
+    display: inline-block;
+    font-size: 30px;
+    line-height: 1;
+    transition: transform 0.25s ease;
+  }
+
+  .work-album-card:not(.is-collapsed) .work-album-toggle__arrow {
+    transform: rotate(180deg);
+  }
+
   .work-album-card--divider {
     margin-top: 24px;
   }


### PR DESCRIPTION
### Motivation
- Facilitar la navegación en móviles dentro del popup de "Trabajos" mostrando solo el título y la miniatura por defecto y permitiendo expandir cada tarjeta para ver canciones y descripción.
- Mantener la accesibilidad añadiendo controles con atributos `aria-expanded` y `aria-label` para indicar el estado de la tarjeta.

### Description
- En `script.js` se envuelven las canciones y la descripción de cada álbum en un contenedor `div.work-album-collapsible` y se inserta un botón `button.work-album-toggle` con una flecha para expandir/contraer; las tarjetas se inician con la clase `is-collapsed` y el contenido colapsado (`hidden`).
- El toggle actualiza `aria-expanded` y `aria-label` y alterna la clase `is-collapsed` y la visibilidad del contenido al hacer clic.
- En `style.css` se añadieron reglas móviles para `work-album-collapsible`, `work-album-toggle` y `work-album-toggle__arrow`, incluyendo la rotación de la flecha cuando la tarjeta está expandida.
- Los cambios afectan únicamente la construcción dinámica de las tarjetas dentro del popup `Trabajos` en móvil y mantienen el comportamiento existente para el resto de la interfaz.

### Testing
- Se ejecutó el chequeo de sintaxis JavaScript con `node --check script.js` y pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c002771a6c832b9a68394a8f59e41b)