### PR TITLE
Reducir altura de tarjetas en el popup móvil de Trabajos

### DIFF
--- a/style.css
+++ b/style.css
@@ -1595,6 +1595,9 @@ body.light-mode .audio-item__progress {
     width: min(94%, 390px);
     margin: 0 auto;
     display: block;
+    max-height: 72px;
+    overflow: hidden;
+    border-radius: 2px;
   }
 
   .work-album > .info {
@@ -1625,6 +1628,24 @@ body.light-mode .audio-item__progress {
     margin-right: 0;
     margin-bottom: 12px;
     align-self: center;
+  }
+
+  .work-album .thumb {
+    width: 100%;
+    height: 72px;
+    object-fit: cover;
+    object-position: center 28%;
+    aspect-ratio: auto;
+  }
+
+  .work-album > .info h3 {
+    margin-bottom: 6px;
+    font-size: 0.96rem;
+    line-height: 1.2;
+  }
+
+  .work-album-card {
+    padding: 10px 10px 12px;
   }
 
   .work-album .thumb {


### PR DESCRIPTION
### Motivation
- Reducir la altura visible de las tarjetas en la ventana emergente `Trabajos` en móvil para mostrar el título y solo un fragmento de la miniatura y así disminuir el scroll en pantallas pequeñas.
- Aplicar el cambio únicamente mediante estilos para mantener la funcionalidad de colapsado/expansión existente.

### Description
- Se actualizó `style.css` añadiendo `max-height: 72px`, `overflow: hidden` y `border-radius: 2px` a ` .work-album > .album-link` para recortar la miniatura.
- Se añadió una regla para ` .work-album .thumb` con `height: 72px`, `object-fit: cover` y `object-position: center 28%` para mostrar un fragmento controlado de la imagen.
- Se ajustó la tipografía y el espaciado compacto para móvil en ` .work-album > .info h3` y el ` .work-album-card` para mejorar la legibilidad en vista reducida.
- Los cambios quedan limitados a estilos (móvil / popup de Trabajos) sin modificar HTML ni lógica en `script.js`.

### Testing
- Revisión estática del archivo `style.css` y comparación del diff confirmaron la presencia y sintaxis de las nuevas reglas (aprobado).
- Inspección del código verificó que no se tocaron estructuras HTML/JS relacionadas con el colapsado (aprobado).
- No hay suite de tests automatizada para UI en el repositorio, por lo que la validación visual final requiere revisión en dispositivo/emulador; los checks de código pasaron.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0065abd64832ba06240182f9a9791)