### PR TITLE
Agregar marco pixel-art móvil a tarjetas de álbum en 'Trabajos'

### DIFF
--- a/script.js
+++ b/script.js
@@ -264,8 +264,11 @@ function organizeTrabajosAlbumsForMobile(popup) {
       card.classList.add('work-album-card--divider');
       album.classList.remove('album-divider');
     }
+    const frame = document.createElement('div');
+    frame.className = 'album-frame';
 
     gallery.insertBefore(card, album);
+    card.appendChild(frame);
     card.appendChild(album);
     const collapsibleContent = document.createElement('div');
     collapsibleContent.className = 'work-album-collapsible';

--- a/style.css
+++ b/style.css
@@ -1506,11 +1506,29 @@ body.light-mode .audio-item__progress {
   }
 
   .work-album-card {
+    position: relative;
     width: 92%;
     margin: 0 auto 18px;
     padding: 12px 10px 14px;
-    border: 4px solid #000;
-    background: rgb(97, 97, 97);
+    border: none;
+    background: transparent;
+    box-sizing: border-box;
+  }
+
+  .work-album-card > :not(.album-frame) {
+    position: relative;
+    z-index: 1;
+  }
+
+  .work-album-card .album-frame {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    pointer-events: none;
+    border: 32px solid transparent;
+    border-image-source: url("assets/contenedor web.png");
+    border-image-slice: 32 fill;
+    border-image-repeat: repeat;
     box-sizing: border-box;
   }
 


### PR DESCRIPTION
### Motivation
- Aplicar un marco pixel art usando `border-image` a los contenedores de los álbumes en la versión móvil de la sección de `trabajos` sin cambiar la estructura general de la web. 
- El marco debe superponerse al contenedor, quedar por debajo del contenido interactuable y no romper el layout ni el crecimiento vertical de las tarjetas.

### Description
- Se añade una capa visual interna creada dinámicamente: se inserta un `div` con clase `album-frame` dentro de cada `work-album-card` en `script.js` (móvil) mediante `document.createElement('div')` y `card.appendChild(frame)`. 
- Se convierte la tarjeta en un contenedor apilable con `position: relative` en `style.css` y se elimina el borde/background previa para dejar espacio al nuevo marco. 
- Se asegura que el contenido quede por encima con la regla `.work-album-card > :not(.album-frame) { position: relative; z-index: 1; }`. 
- El marco se implementa con `border: 32px solid transparent`, `border-image-source: url("assets/contenedor web.png")`, `border-image-slice: 32 fill` y `border-image-repeat: repeat`, además de `position: absolute; inset: 0; pointer-events: none; z-index: 0;` para superponerse sin bloquear interacción.

### Testing
- Se ejecutó `git diff --check` exitosamente, sin errores reportados. 
- Se ejecutó `node --check script.js` exitosamente para validar la sintaxis del script. 
- Se creó un commit con los cambios en `script.js` y `style.css` (commit aplicado correctamente).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c63b6e8a80832b85ce1da871294408)