### PR TITLE
Añadir marcos pixel-art con border-image a acordeones móviles de Música

### DIFF
--- a/script.js
+++ b/script.js
@@ -908,6 +908,10 @@ function populateMobileMusicSections() {
     block.dataset.section = section.key;
     block.open = index === 0;
 
+    const frame = document.createElement('div');
+    frame.className = 'music-frame';
+    frame.setAttribute('aria-hidden', 'true');
+
     const summary = document.createElement('summary');
     summary.className = 'mobile-music-accordion__summary';
     summary.innerHTML = `
@@ -933,6 +937,7 @@ function populateMobileMusicSections() {
       content.appendChild(experimentsContainer);
     }
 
+    block.appendChild(frame);
     block.appendChild(summary);
     block.appendChild(content);
     container.appendChild(block);

--- a/style.css
+++ b/style.css
@@ -1315,22 +1315,48 @@ body.light-mode .audio-item__progress {
   }
 
   .mobile-music-accordion {
-    border: 3px solid #000;
-    background: var(--mobile-music-accordion-base-bg);
-    box-shadow: 0 0 0 2px var(--mobile-music-accordion-accent, var(--mobile-music-accordion-instrumentales-color));
+    position: relative;
+    border: none;
+    background: transparent;
     color: #fff;
+    box-sizing: border-box;
+    overflow: visible;
   }
 
   .mobile-music-accordion[data-section='instrumentales'] {
     --mobile-music-accordion-accent: var(--mobile-music-accordion-instrumentales-color);
+    --mobile-music-frame-image: url("assets/contenedor música inst.png");
   }
 
   .mobile-music-accordion[data-section='experimentos'] {
     --mobile-music-accordion-accent: var(--mobile-music-accordion-experimentos-color);
+    --mobile-music-frame-image: url("assets/contenedor música exp.png");
   }
 
   .mobile-music-accordion[data-section='covers'] {
     --mobile-music-accordion-accent: var(--mobile-music-accordion-covers-color);
+    --mobile-music-frame-image: url("assets/contenedor música cov.png");
+  }
+
+  .mobile-music-accordion > :not(.music-frame) {
+    position: relative;
+    z-index: 1;
+  }
+
+  .mobile-music-accordion .music-frame {
+    position: absolute;
+    top: 0;
+    bottom: -16px;
+    left: -16px;
+    right: -16px;
+    z-index: 0;
+    pointer-events: none;
+    border: 32px solid transparent;
+    border-style: solid;
+    border-image-source: var(--mobile-music-frame-image);
+    border-image-slice: 32 fill;
+    border-image-repeat: repeat;
+    box-sizing: border-box;
   }
 
   .mobile-music-accordion__summary {
@@ -1364,7 +1390,6 @@ body.light-mode .audio-item__progress {
 
   .mobile-music-accordion__content {
     min-height: var(--mobile-music-accordion-content-min-height);
-    border-top: 3px solid #000;
     background: var(--mobile-music-accordion-content-bg);
   }
 
@@ -1376,9 +1401,7 @@ body.light-mode .audio-item__progress {
   }
 
   body.light-mode .mobile-music-accordion {
-    background: var(--mobile-music-accordion-base-bg-light);
     color: #000;
-    box-shadow: 0 0 0 2px var(--mobile-music-accordion-accent-light, var(--mobile-music-accordion-instrumentales-color-light));
   }
 
   body.light-mode .mobile-music-accordion[data-section='instrumentales'] {


### PR DESCRIPTION
### Motivation
- Replicar el sistema de marco con `border-image` ya usado en los álbumes de la sección Trabajos para los contenedores desplegables móviles de la sección Música, manteniendo la estructura existente y asegurando que el contenido quede por encima del marco mientras el fondo puede crecer en altura.

### Description
- Inserté un elemento decorativo `div.music-frame` con `aria-hidden="true"` dentro de cada bloque creado por `populateMobileMusicSections()` en `script.js` para cada sección (`instrumentales`, `experimentos`, `covers`).
- En `style.css` convertí `.mobile-music-accordion` en `position: relative` y añadí variables por sección `--mobile-music-frame-image` apuntando a `assets/contenedor música inst.png`, `assets/contenedor música exp.png` y `assets/contenedor música cov.png` respectivamente.
- Implementé `.music-frame` con `position: absolute; top: 0; bottom: -16px; left: -16px; right: -16px; pointer-events: none; z-index: 0; border: 32px solid transparent; border-style: solid; border-image-source: var(--mobile-music-frame-image); border-image-slice: 32 fill; border-image-repeat: repeat;` para reproducir la lógica de `.album-frame` y permitir que el fondo crezca sin romperse.
- Garantizé que el contenido quede por encima usando `.mobile-music-accordion > :not(.music-frame) { position: relative; z-index: 1; }` y mantuve la aplicación limitada al contexto móvil del popup Música.

### Testing
- Ejecuté `node --check script.js` y la comprobación de sintaxis pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c64891a344832b8478011c81003f30)