### PR TITLE
Replace mobile music accordion with panel-based UI and decorative frame styling

### DIFF
--- a/script.js
+++ b/script.js
@@ -902,21 +902,21 @@ function populateMobileMusicSections() {
     { key: 'covers', title: 'Covers' }
   ];
 
-  sections.forEach((section, index) => {
-    const block = document.createElement('details');
-    block.className = 'mobile-music-accordion';
+  sections.forEach(section => {
+    const block = document.createElement('section');
+    block.className = 'mobile-music-panel';
     block.dataset.section = section.key;
-    block.open = index === 0;
 
-    const summary = document.createElement('summary');
-    summary.className = 'mobile-music-accordion__summary';
-    summary.innerHTML = `
-      <span>${section.title}</span>
-      <span class="mobile-music-accordion__indicator" aria-hidden="true">+</span>
-    `;
+    const frame = document.createElement('div');
+    frame.className = 'music-frame';
+    frame.setAttribute('aria-hidden', 'true');
+
+    const title = document.createElement('h3');
+    title.className = 'mobile-music-panel__title';
+    title.textContent = section.title;
 
     const content = document.createElement('div');
-    content.className = 'mobile-music-accordion__content';
+    content.className = 'mobile-music-panel__content';
     content.dataset.section = section.key;
 
     if (section.key === 'covers') {
@@ -933,7 +933,8 @@ function populateMobileMusicSections() {
       content.appendChild(experimentsContainer);
     }
 
-    block.appendChild(summary);
+    block.appendChild(frame);
+    block.appendChild(title);
     block.appendChild(content);
     container.appendChild(block);
   });
@@ -941,7 +942,7 @@ function populateMobileMusicSections() {
 
 function populateInstrumentals() {
   const container = isMobile
-    ? document.querySelector('#popup-instrumentales .mobile-music-accordion__content[data-section="instrumentales"]')
+    ? document.querySelector('#popup-instrumentales .mobile-music-panel__content[data-section="instrumentales"]')
     : document.querySelector('#popup-instrumentales .popup-content');
   if (!container) return;
   instrumentals.forEach(inst => {

--- a/style.css
+++ b/style.css
@@ -1314,58 +1314,68 @@ body.light-mode .audio-item__progress {
     gap: 10px;
   }
 
-  .mobile-music-accordion {
-    border: 3px solid #000;
-    background: var(--mobile-music-accordion-base-bg);
-    box-shadow: 0 0 0 2px var(--mobile-music-accordion-accent, var(--mobile-music-accordion-instrumentales-color));
+  .mobile-music-panel {
+    position: relative;
+    border: none;
+    background: transparent;
     color: #fff;
+    box-sizing: border-box;
+    overflow: visible;
+    margin-bottom: 12px;
   }
 
-  .mobile-music-accordion[data-section='instrumentales'] {
-    --mobile-music-accordion-accent: var(--mobile-music-accordion-instrumentales-color);
+  .mobile-music-panel:last-child {
+    margin-bottom: 0;
   }
 
-  .mobile-music-accordion[data-section='experimentos'] {
-    --mobile-music-accordion-accent: var(--mobile-music-accordion-experimentos-color);
+  .mobile-music-panel[data-section='instrumentales'] {
+    --mobile-music-frame-image: url("assets/contenedor música inst.png");
   }
 
-  .mobile-music-accordion[data-section='covers'] {
-    --mobile-music-accordion-accent: var(--mobile-music-accordion-covers-color);
+  .mobile-music-panel[data-section='experimentos'] {
+    --mobile-music-frame-image: url("assets/contenedor música exp.png");
   }
 
-  .mobile-music-accordion__summary {
-    list-style: none;
-    cursor: pointer;
+  .mobile-music-panel[data-section='covers'] {
+    --mobile-music-frame-image: url("assets/contenedor música cov.png");
+  }
+
+  .mobile-music-panel > :not(.music-frame) {
+    position: relative;
+    z-index: 1;
+  }
+
+  .mobile-music-panel .music-frame {
+    position: absolute;
+    top: 0;
+    bottom: -16px;
+    left: -16px;
+    right: -16px;
+    z-index: 0;
+    pointer-events: none;
+    border: 32px solid transparent;
+    border-style: solid;
+    border-image-source: var(--mobile-music-frame-image);
+    border-image-slice: 32 fill;
+    border-image-repeat: repeat;
+    box-sizing: border-box;
+  }
+
+  .mobile-music-panel__title {
+    margin: 0;
     padding: 14px;
     min-height: var(--mobile-music-accordion-summary-min-height);
     display: flex;
     align-items: center;
-    justify-content: space-between;
     text-transform: uppercase;
     letter-spacing: 0.08em;
     font-size: 13px;
   }
 
-  .mobile-music-accordion__summary::marker,
-  .mobile-music-accordion__summary::-webkit-details-marker {
-    display: none;
-    content: '';
-  }
-
-  .mobile-music-accordion__indicator {
-    font-size: 18px;
-    line-height: 1;
-    transition: transform 0.2s ease;
-  }
-
-  .mobile-music-accordion[open] .mobile-music-accordion__indicator {
-    transform: rotate(45deg);
-  }
-
-  .mobile-music-accordion__content {
+  .mobile-music-panel__content {
     min-height: var(--mobile-music-accordion-content-min-height);
-    border-top: 3px solid #000;
     background: var(--mobile-music-accordion-content-bg);
+    padding-bottom: 8px;
   }
 
   .mobile-covers-container {
@@ -1375,25 +1385,11 @@ body.light-mode .audio-item__progress {
     background: rgba(0, 0, 0, 0.25);
   }
 
-  body.light-mode .mobile-music-accordion {
-    background: var(--mobile-music-accordion-base-bg-light);
+  body.light-mode .mobile-music-panel {
     color: #000;
-    box-shadow: 0 0 0 2px var(--mobile-music-accordion-accent-light, var(--mobile-music-accordion-instrumentales-color-light));
   }
 
-  body.light-mode .mobile-music-accordion[data-section='instrumentales'] {
-    --mobile-music-accordion-accent-light: var(--mobile-music-accordion-instrumentales-color-light);
-  }
-
-  body.light-mode .mobile-music-accordion[data-section='experimentos'] {
-    --mobile-music-accordion-accent-light: var(--mobile-music-accordion-experimentos-color-light);
-  }
-
-  body.light-mode .mobile-music-accordion[data-section='covers'] {
-    --mobile-music-accordion-accent-light: var(--mobile-music-accordion-covers-color-light);
-  }
-
-  body.light-mode .mobile-music-accordion__content {
+  body.light-mode .mobile-music-panel__content {
     background: var(--mobile-music-accordion-content-bg-light);
   }
 


### PR DESCRIPTION
### Motivation

- Replace the old `<details>`-based mobile accordion with a more flexible panel structure to support a decorative frame and improved layout. 
- Unify and simplify class names and selectors used by mobile music sections for more predictable styling and DOM queries.

### Description

- Replaced the accordion markup in `populateMobileMusicSections()` by creating `section.mobile-music-panel` elements with a `.music-frame` container and a heading `.mobile-music-panel__title` instead of using `<summary>` and `<details>` behavior. 
- Updated child content selectors and usage in `populateInstrumentals()` to target `.mobile-music-panel__content` for mobile views. 
- Removed the old accordion-specific CSS and added new rules for `.mobile-music-panel`, `.music-frame` (using `border-image` to render decorative container artwork), `.mobile-music-panel__title`, and `.mobile-music-panel__content`, plus light-mode variants. 
- Added CSS custom properties to map per-section frame images for `instrumentales`, `experimentos`, and `covers` and adjusted spacing/margins to match the new visual structure.

### Testing

- Ran linter with `npm run lint` and it completed successfully. 
- Built the app with `npm run build` and the build succeeded. 
- Executed the test suite with `npm test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c64891a344832b8478011c81003f30)