### PR TITLE
Fix mobile music accordion frame rendering and fill

### DIFF
--- a/script.js
+++ b/script.js
@@ -907,7 +907,7 @@ function populateMobileMusicSections() {
     accordion.className = 'mobile-music-accordion';
     accordion.dataset.section = section.id;
 
-    const frame = document.createElement('span');
+    const frame = document.createElement('div');
     frame.className = 'music-frame';
     frame.setAttribute('aria-hidden', 'true');
 

--- a/style.css
+++ b/style.css
@@ -1317,6 +1317,8 @@ body.light-mode .audio-item__progress {
 
   .mobile-music-accordion {
     position: relative;
+    width: 100%;
+    min-height: var(--mobile-music-accordion-summary-min-height);
     border: none;
     background: transparent;
     color: #fff;
@@ -1326,17 +1328,17 @@ body.light-mode .audio-item__progress {
 
   .mobile-music-accordion[data-section='instrumentales'] {
     --mobile-music-accordion-accent: var(--mobile-music-accordion-instrumentales-color);
-    --mobile-music-frame-image: url("assets/contenedor música inst.png");
+    --mobile-music-frame-image: url("assets/contenedor%20m%C3%BAsica%20inst.png");
   }
 
   .mobile-music-accordion[data-section='experimentos'] {
     --mobile-music-accordion-accent: var(--mobile-music-accordion-experimentos-color);
-    --mobile-music-frame-image: url("assets/contenedor música exp.png");
+    --mobile-music-frame-image: url("assets/contenedor%20m%C3%BAsica%20exp.png");
   }
 
   .mobile-music-accordion[data-section='covers'] {
     --mobile-music-accordion-accent: var(--mobile-music-accordion-covers-color);
-    --mobile-music-frame-image: url("assets/contenedor música cov.png");
+    --mobile-music-frame-image: url("assets/contenedor%20m%C3%BAsica%20cov.png");
   }
 
   .mobile-music-accordion > :not(.music-frame) {
@@ -1350,12 +1352,15 @@ body.light-mode .audio-item__progress {
     bottom: 0;
     left: 0;
     right: 0;
+    display: block;
+    width: 100%;
+    height: 100%;
     z-index: 0;
     pointer-events: none;
     border: 32px solid transparent;
     border-style: solid;
     border-image-source: var(--mobile-music-frame-image);
-    border-image-slice: 32;
+    border-image-slice: 32 fill;
     border-image-repeat: stretch;
     box-sizing: border-box;
   }
@@ -1364,7 +1369,7 @@ body.light-mode .audio-item__progress {
     list-style: none;
     cursor: pointer;
     padding: 18px 20px 16px;
-    min-height: 56px;
+    min-height: var(--mobile-music-accordion-summary-min-height);
     display: flex;
     align-items: center;
     justify-content: flex-start;
@@ -1381,7 +1386,7 @@ body.light-mode .audio-item__progress {
   }
 
   .mobile-music-accordion__content {
-    min-height: 110px;
+    min-height: var(--mobile-music-accordion-content-min-height);
     padding: 0 16px 14px;
     background: var(--mobile-music-accordion-content-bg);
     border-radius: 0 0 8px 8px;


### PR DESCRIPTION
### Motivation
- Corrigir por qué los contenedores de la sección de Música en móvil no mostraban las imágenes del marco ni el centro del `border-image` cuando estaban cerrados o al abrirse.  
- Identifiqué que la causa combinada eran rutas con espacios/acentos, `border-image-slice` sin `fill` y que el elemento de marco era inline/without explicit size.  
- Quería arreglarlo sin rehacer la estructura ni la lógica existente del desplegable.  

### Description
- Actualicé las rutas usadas por la variable CSS `--mobile-music-frame-image` a versiones URL-encoded para evitar problemas con espacios/acentos en móviles; los archivos originales siguen existiendo en `assets/`.  
- Forcé que el acordeón tenga tamaño real en estado cerrado añadiendo `width: 100%` y `min-height: var(--mobile-music-accordion-summary-min-height)` a `.mobile-music-accordion`.  
- Hice que el elemento de marco ocupe siempre el contenedor con `display: block; width: 100%; height: 100%` y aseguré `border-style: solid` y `border-image-source` use la variable; además cambié `border-image-slice` a `32 fill` para que se pinte también el centro.  
- Ajusté la creación del nodo de marco en JS de `span` a `div` (en `populateMobileMusicSections`) para evitar comportamiento inline que impedía altura real del marco; no he reescrito la lógica del `details`/`summary`, sólo reforcé el marco.  

### Testing
- Ejecutado `node --check script.js` y pasó correctamente.  
- Comprobación de existencia de archivos de imagen con espacio/acentos devolvió `OK` para `assets/contenedor música inst.png`, `assets/contenedor música exp.png` y `assets/contenedor música cov.png`.  
- Los cambios fueron guardados y commiteados localmente; no se generaron tests visuales automatizados en este entorno (no se pudo tomar captura de pantalla del navegador aquí).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c64e597f7c832b9f207f06c6b07d0f)