### PR TITLE
Mantener border-image en desplegables de Música móvil añadiendo altura mínima

### DIFF
--- a/script.js
+++ b/script.js
@@ -856,10 +856,6 @@ function resetMobileMusicPopup() {
     dropdown.dataset.section = section.id;
     dropdown.style.setProperty('--mobile-music-frame-image', `url("${section.frameImage}")`);
 
-    const frame = document.createElement('span');
-    frame.className = 'mobile-music-dropdown__frame';
-    frame.setAttribute('aria-hidden', 'true');
-
     const summary = document.createElement('summary');
     summary.className = 'mobile-music-dropdown__summary';
     summary.textContent = section.title;
@@ -868,7 +864,6 @@ function resetMobileMusicPopup() {
     content.className = 'mobile-music-dropdown__content';
     content.innerHTML = '<p class="mobile-music-dropdown__placeholder">Próximamente…</p>';
 
-    dropdown.appendChild(frame);
     dropdown.appendChild(summary);
     dropdown.appendChild(content);
     wrapper.appendChild(dropdown);

--- a/style.css
+++ b/style.css
@@ -1310,41 +1310,23 @@ body.light-mode .audio-item__progress {
   }
 
   .mobile-music-dropdown {
-    position: relative;
     width: 100%;
-    border: 0;
+    min-height: 112px;
+    border: 32px solid transparent;
+    border-image-source: var(--mobile-music-frame-image);
+    border-image-slice: 32 fill;
+    border-image-repeat: stretch;
     background: transparent;
     color: #fff;
     box-sizing: border-box;
-    overflow: visible;
-  }
-
-  .mobile-music-dropdown > :not(.mobile-music-dropdown__frame) {
-    position: relative;
-    z-index: 1;
-  }
-
-  .mobile-music-dropdown__frame {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    display: block;
-    z-index: 0;
-    pointer-events: none;
-    border: 32px solid transparent;
-    border-image-source: var(--mobile-music-frame-image);
-    border-image-slice: 32;
-    border-image-repeat: stretch;
-    box-sizing: border-box;
+    overflow: hidden;
   }
 
   .mobile-music-dropdown__summary {
     list-style: none;
     cursor: pointer;
-    min-height: 64px;
-    padding: 18px 22px 16px;
+    min-height: 48px;
+    padding: 10px 14px 8px;
     display: flex;
     align-items: center;
     justify-content: flex-start;
@@ -1361,8 +1343,8 @@ body.light-mode .audio-item__progress {
   }
 
   .mobile-music-dropdown__content {
-    min-height: 120px;
-    padding: 0 22px 18px;
+    min-height: 88px;
+    padding: 0 14px 10px;
   }
 
   .mobile-music-dropdown__placeholder {


### PR DESCRIPTION
### Motivation
- El elemento decorativo absoluto que aplicaba el `border-image` no tenía altura propia cuando el `details` estaba contraído, por lo que el marco no se renderizaba completo en estado cerrado.

### Description
- Eliminé el `span.mobile-music-dropdown__frame` creado en `resetMobileMusicPopup()` para evitar depender de un overlay sin altura real y simplificar la estructura del DOM en `script.js`.
- Apliqué el marco texturado directamente al contenedor `details.mobile-music-dropdown` en `style.css` y mantuve `border: 32px solid transparent` y `border-image-slice: 32 fill` tal como se pidió.
- Añadí `min-height: 112px` a `.mobile-music-dropdown` y ajusté las alturas y paddings internos de `summary` y `.mobile-music-dropdown__content` para asegurar que el elemento con `border-image` siempre tenga altura real tanto cerrado como abierto.
- Quité la regla absoluta/overlay previa y ajusté `overflow` para que el borde y el contenido se comporten correctamente sin elementos superpuestos.

### Testing
- Ejecuté `node --check script.js` y la verificación de sintaxis de JavaScript pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c654bd3ec8832b932b7b49540dac36)