### PR TITLE
Añade texto introductorio en popup móvil de Música

### DIFF
--- a/script.js
+++ b/script.js
@@ -829,6 +829,10 @@ function resetMobileMusicPopup() {
   if (!container) return;
   container.innerHTML = '';
 
+  const introText = document.createElement('p');
+  introText.className = 'mobile-music-intro';
+  introText.textContent = 'Si te interesa mi sonido, aquí tienes una selección de covers, instrumentales y pruebas que he hecho últimamente:';
+
   const musicSections = [
     {
       id: 'instrumentales',
@@ -869,6 +873,7 @@ function resetMobileMusicPopup() {
     wrapper.appendChild(dropdown);
   });
 
+  container.appendChild(introText);
   container.appendChild(wrapper);
 }
 

--- a/style.css
+++ b/style.css
@@ -1303,6 +1303,16 @@ body.light-mode .audio-item__progress {
     padding: 6px 0 12px;
   }
 
+  .mobile-music-intro {
+    margin: 2px auto 4px;
+    width: 90%;
+    color: #fff;
+    text-align: center;
+    font-family: inherit;
+    font-size: 13px;
+    line-height: 1.45;
+  }
+
   .mobile-music-dropdowns {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
### Motivation
- Hacer más clara la sección de "Música" en móvil mostrando un texto introductorio encima de los bloques desplegables para contextualizar covers, instrumentales y experimentos.

### Description
- En `script.js` se añadió un párrafo dinámico (`<p class="mobile-music-intro">`) en `resetMobileMusicPopup()` con el copy solicitado y se inserta antes del contenedor de dropdowns (`.mobile-music-dropdowns`).
- En `style.css` se añadió la clase `.mobile-music-intro` para usar la tipografía general (`font-family: inherit`), centrar el texto y forzar color blanco con tamaño y espaciado legibles en móvil.
- El texto insertado es: `Si te interesa mi sonido, aquí tienes una selección de covers, instrumentales y pruebas que he hecho últimamente:`.

### Testing
- Se ejecutó la comprobación de sintaxis JavaScript con `node --check script.js` y no reportó errores (exit 0).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c66d453b44832b9e13136ac1611f66)