### PR TITLE
Añade imagen FLECHA en popup de música móvil

### DIFF
--- a/script.js
+++ b/script.js
@@ -833,6 +833,11 @@ function resetMobileMusicPopup() {
   introText.className = 'mobile-music-intro';
   introText.textContent = 'Si te interesa mi sonido, aquí tienes una selección de covers, instrumentales y pruebas que he hecho últimamente:';
 
+  const introArrow = document.createElement('img');
+  introArrow.className = 'mobile-music-intro-arrow';
+  introArrow.src = 'assets/FLECHA.png';
+  introArrow.alt = 'Flecha decorativa';
+
   const musicSections = [
     {
       id: 'instrumentales',
@@ -874,6 +879,7 @@ function resetMobileMusicPopup() {
   });
 
   container.appendChild(introText);
+  container.appendChild(introArrow);
   container.appendChild(wrapper);
 }
 

--- a/style.css
+++ b/style.css
@@ -1313,6 +1313,13 @@ body.light-mode .audio-item__progress {
     line-height: 1.45;
   }
 
+  .mobile-music-intro-arrow {
+    display: block;
+    width: 15%;
+    height: auto;
+    margin: 0 auto 4px;
+  }
+
   .mobile-music-dropdowns {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
### Motivation
- Añadir una imagen decorativa justo debajo del texto introductorio de la ventana emergente de la sección de música en la versión móvil para mejorar la estética y la señalización visual.
- La imagen debe ocupar el 15% del ancho del contenedor y mantener sus proporciones para no romper el diseño en distintos tamaños de pantalla.

### Description
- Se crea y añade un elemento `<img>` con clase `mobile-music-intro-arrow` en `resetMobileMusicPopup()` y se inserta entre el párrafo introductorio y los desplegables (archivo `script.js`).
- Se añade la clase CSS `.mobile-music-intro-arrow` en `style.css` con `width: 15%`, `height: auto` y centrado horizontal mediante `display: block` y `margin` para que la imagen (`assets/FLECHA.png`) ocupe el 15% y mantenga proporciones.

### Testing
- Se ejecutó la comprobación sintáctica de JavaScript con `node --check script.js` y pasó sin errores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c670214ca0832baf65e1c8af908b1c)