### PR TITLE
Mejora formato del popup "Música" en móvil: saltos de línea y palabras coloreadas

### DIFF
--- a/script.js
+++ b/script.js
@@ -831,7 +831,13 @@ function resetMobileMusicPopup() {
 
   const introText = document.createElement('p');
   introText.className = 'mobile-music-intro';
-  introText.textContent = 'Si te interesa mi sonido, aquí tienes una selección de covers, instrumentales y pruebas que he hecho últimamente:';
+  introText.innerHTML = `
+    Si te interesa mi <span class="mobile-music-intro__highlight mobile-music-intro__highlight--sound">sonido</span>,<br>
+    aquí tienes una selección de
+    <span class="mobile-music-intro__highlight mobile-music-intro__highlight--covers">covers</span>,
+    <span class="mobile-music-intro__highlight mobile-music-intro__highlight--instrumentals">instrumentales</span><br>
+    y <span class="mobile-music-intro__highlight mobile-music-intro__highlight--experiments">pruebas</span> que he hecho últimamente:
+  `;
 
   const introArrow = document.createElement('img');
   introArrow.className = 'mobile-music-intro-arrow';

--- a/style.css
+++ b/style.css
@@ -1313,6 +1313,26 @@ body.light-mode .audio-item__progress {
     line-height: 1.45;
   }
 
+  .mobile-music-intro__highlight {
+    font-weight: 700;
+  }
+
+  .mobile-music-intro__highlight--sound {
+    color: #ffd54f;
+  }
+
+  .mobile-music-intro__highlight--covers {
+    color: #80deea;
+  }
+
+  .mobile-music-intro__highlight--instrumentals {
+    color: #a5d6a7;
+  }
+
+  .mobile-music-intro__highlight--experiments {
+    color: #f48fb1;
+  }
+
   .mobile-music-intro-arrow {
     display: block;
     width: 15%;


### PR DESCRIPTION
### Motivation
- Facilitar el formateo del texto en la ventana emergente de la sección `Música` en la versión móvil para permitir saltos de línea y destacar palabras clave en color. 
- Alinear el formato de esa ventana con el esquema usado en las secciones como `Contacto` y `Plugins` para una experiencia consistente. 

### Description
- Reemplazado el `textContent` por `innerHTML` en la función `resetMobileMusicPopup` dentro de `script.js` para permitir `<br>` y marcado HTML con `span` para palabras resaltadas. 
- Añadidas clases CSS reutilizables en `style.css` (`.mobile-music-intro__highlight` y variantes `--sound`, `--covers`, `--instrumentals`, `--experiments`) para aplicar color y peso tipográfico a las palabras clave. 
- Los cambios afectan únicamente el texto introductorio y los estilos visuales; no se modificó la lógica de los desplegables ni la estructura de los popups. 
- Archivos modificados: `script.js` y `style.css`. 

### Testing
- Ejecutado `git diff --check` sin errores. 
- Ejecutado `node --check script.js` sin errores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c673e33d08832b818c74c289b790cc)