### PR TITLE
Añade texto introductorio y flecha en el popup móvil de Trabajos

### DIFF
--- a/script.js
+++ b/script.js
@@ -244,6 +244,19 @@ zones.forEach(zone => {
 function organizeTrabajosAlbumsForMobile(popup) {
   const gallery = popup.querySelector('.trabajos-gallery');
   if (!gallery || gallery.querySelector('.work-album-card')) return;
+  const popupContent = popup.querySelector('.popup-content');
+
+  if (popupContent && !popupContent.querySelector('.trabajos-mobile-intro')) {
+    const introBlock = document.createElement('div');
+    introBlock.className = 'trabajos-mobile-intro';
+    introBlock.innerHTML = `
+      <p class="trabajos-mobile-intro__text">
+        Aquí encontrarás un listado de todos los trabajos en los que he participado tanto en producción audiovisual como en música y sonido
+      </p>
+      <img class="trabajos-mobile-intro__arrow" src="assets/FLECHA.png" alt="Flecha decorativa" />
+    `;
+    popupContent.insertBefore(introBlock, gallery);
+  }
 
   const albums = Array.from(gallery.querySelectorAll('.work-album'));
   albums.forEach(album => {

--- a/style.css
+++ b/style.css
@@ -1503,6 +1503,26 @@ body.light-mode .audio-item__progress {
     font-size: 13px;
   }
 
+  .trabajos-mobile-intro {
+    width: 92%;
+    margin: 0 auto 16px;
+    text-align: center;
+  }
+
+  .trabajos-mobile-intro__text {
+    margin: 0;
+    color: #fff;
+    line-height: 1.45;
+    text-align: center;
+  }
+
+  .trabajos-mobile-intro__arrow {
+    display: block;
+    width: 10%;
+    min-width: 28px;
+    margin: 10px auto 0;
+  }
+
   .work-album-card {
     position: relative;
     width: 92%;


### PR DESCRIPTION
### Motivation
- Añadir un texto introductorio centrado y en blanco encima de los bloques contenedores de los álbumes en la ventana emergente de `Trabajos` para la versión móvil. 
- Incluir la imagen decorativa `FLECHA` entre el texto y los bloques desplegables y limitar su tamaño al 10% del ancho de la ventana para mantener coherencia con otras ventanas móviles.

### Description
- `script.js`: en `organizeTrabajosAlbumsForMobile` se inyecta dinámicamente un bloque `.trabajos-mobile-intro` antes de `.trabajos-gallery` con el texto solicitado y la imagen `assets/FLECHA.png`, y se evita la inserción duplicada mediante una comprobación previa. 
- `style.css`: se añadieron reglas para `.trabajos-mobile-intro`, `.trabajos-mobile-intro__text` (texto centrado y en blanco) y `.trabajos-mobile-intro__arrow` (ancho `10%` y `min-width: 28px`, centrada). 
- Los cambios aplican solo al popup móvil de `Trabajos` y no modifican la lógica de escritorio ni otras ventanas emergentes.

### Testing
- Se ejecutó la comprobación de sintaxis JavaScript con `node --check script.js` y pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d24ba71da4832b95593a6a22e6652c)