### PR TITLE
Highlight keywords in mobile Trabajos popup

### DIFF
--- a/script.js
+++ b/script.js
@@ -251,7 +251,7 @@ function organizeTrabajosAlbumsForMobile(popup) {
     introBlock.className = 'trabajos-mobile-intro';
     introBlock.innerHTML = `
       <p class="trabajos-mobile-intro__text">
-        Aquí encontrarás un listado de todos los trabajos en los que he participado tanto en producción audiovisual como en música y sonido
+        Aquí encontrarás un listado de todos los <span class="trabajos-mobile-intro__highlight trabajos-mobile-intro__highlight--trabajos">trabajos</span> en los que he participado tanto en <span class="trabajos-mobile-intro__highlight trabajos-mobile-intro__highlight--audiovisual">producción audiovisual</span> como en <span class="trabajos-mobile-intro__highlight trabajos-mobile-intro__highlight--musica">música</span> y <span class="trabajos-mobile-intro__highlight trabajos-mobile-intro__highlight--sonido">sonido</span>
       </p>
       <img class="trabajos-mobile-intro__arrow" src="assets/FLECHA.png" alt="Flecha decorativa" />
     `;

--- a/style.css
+++ b/style.css
@@ -1517,6 +1517,26 @@ body.light-mode .audio-item__progress {
     margin: 10px auto 0;
   }
 
+  .trabajos-mobile-intro__highlight {
+    font-weight: 700;
+  }
+
+  .trabajos-mobile-intro__highlight--trabajos {
+    color: #ff6bd6;
+  }
+
+  .trabajos-mobile-intro__highlight--audiovisual {
+    color: #5fffb8;
+  }
+
+  .trabajos-mobile-intro__highlight--musica {
+    color: #ffd166;
+  }
+
+  .trabajos-mobile-intro__highlight--sonido {
+    color: #79a7ff;
+  }
+
   .trabajos-mobile-intro__arrow {
     display: block;
     width: 15%;


### PR DESCRIPTION
### Motivation
- Permitir colorear palabras clave dentro de la introducción del popup móvil de la sección `Trabajos` para que puedan resaltarse individualmente (palabras: `trabajos`, `producción audiovisual`, `música`, `sonido`).

### Description
- Envuelvo las palabras objetivo en `span` con clases específicas dentro de la función `organizeTrabajosAlbumsForMobile` en `script.js` para que puedan ser estilizadas por separado.
- Añadí la clase base `trabajos-mobile-intro__highlight` y modificadores `--trabajos`, `--audiovisual`, `--musica`, `--sonido` en `style.css` con colores temporales para cada palabra. 
- No se introducen cambios funcionales en la lógica de montaje de la galería; solo cambios de marcado y estilos para el resaltado.

### Testing
- Ejecuté `git diff --check` y `git show --stat --oneline -1`, ambos comandos devolvieron salida sin errores; la verificación pasó correctamente.
- No hay suite de pruebas automatizadas configurada para este sitio estático.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d24f42d6a8832bbf255ddb76e783b1)