### PR TITLE
Añade mensaje centrado sobre `fondomovilfinal` en móvil

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,7 @@
   <div id="mobile-menu"></div>
   <div id="mobile-final">
     <img src="assets/fondomovilfinal.png" alt="Fondo final" />
+    <p id="mobile-final-text">Muchas gracias por llegar hasta aquí.<br>Si te interesa colaborar conmigo o tienes alguna sugerencia, estaré encantado de hablar contigo</p>
   </div>
   <div id="mobile-menu-overlay"></div>
 

--- a/style.css
+++ b/style.css
@@ -806,6 +806,10 @@ body.light-mode .audio-item__progress {
   display: none;
 }
 
+#mobile-final-text {
+  display: none;
+}
+
 .mobile-item {
   width: 100%;
   box-sizing: border-box;
@@ -886,6 +890,22 @@ body.light-mode .audio-item__progress {
     height: 100%;
     object-fit: cover;
     display: block;
+  }
+
+  #mobile-final-text {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: min(85vw, 520px);
+    margin: 0;
+    color: #fff;
+    text-align: center;
+    font-family: 'PixelFont', monospace;
+    font-size: clamp(12px, 3.3vw, 18px);
+    line-height: 1.6;
+    display: block;
+    z-index: 1;
   }
 
   #mobile-social {


### PR DESCRIPTION
### Motivation
- Mostrar un mensaje de agradecimiento y contacto superpuesto sobre la imagen final en la versión móvil, usando la tipografía pixelada del sitio y texto en color blanco.

### Description
- Se añadió el párrafo con el texto solicitado dentro del bloque `#mobile-final` en `index.html` como `<p id="mobile-final-text">...</p>` para que quede sobre `assets/fondomovilfinal.png`.
- Se agregaron reglas en `style.css` para `#mobile-final-text` que lo mantienen oculto por defecto y lo muestran centrado en teléfono mediante `@media (max-width: 768px)` con `font-family: 'PixelFont'`, color blanco, alineación centrada y posicionamiento absoluto centrado (`transform: translate(-50%, -50%)`).
- Los cambios están limitados a `index.html` y `style.css` y no afectan la versión de escritorio (texto oculto fuera de móvil).

### Testing
- Se ejecutó `git -C /workspace/al-one-lndlm.github.io diff --check` y no reportó errores (éxito). 
- Se realizó el commit con `git -C /workspace/al-one-lndlm.github.io commit` y la operación completó correctamente (éxito).
- Se verificó el estado con `git -C /workspace/al-one-lndlm.github.io status --short` y no hay cambios pendientes (éxito).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d371fa3dcc832b99142f0697e774f3)