### PR TITLE
Añadir botón de reinicio en la pantalla final móvil

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,6 +73,9 @@
   <div id="mobile-final">
     <img src="assets/fondomovilfinal.png" alt="Fondo final" />
     <p id="mobile-final-text">Muchas gracias por llegar hasta aquí :) <br> <br>Si te interesa colaborar conmigo o tienes alguna sugerencia, estaré encantado de hablar contigo</p>
+    <button id="mobile-restart-btn" type="button" aria-label="Recargar la página">
+      <img src="assets/restart.png" alt="Recargar página" />
+    </button>
   </div>
   <div id="mobile-menu-overlay"></div>
 

--- a/script.js
+++ b/script.js
@@ -105,6 +105,7 @@ const mobileYoutubeBtn = document.getElementById('mobile-youtube-btn');
 const mobileInstagramBtn = document.getElementById('mobile-instagram-btn');
 const mobileTiktokBtn = document.getElementById('mobile-tiktok-btn');
 const mobileContactBtn = document.getElementById('mobile-contact-btn');
+const mobileRestartBtn = document.getElementById('mobile-restart-btn');
 const mobileFeaturedSocialButtons = document.getElementById('mobile-featured-social-buttons');
 const movementToggleOn = 'assets/ON BUTTON.png';
 const movementToggleOff = 'assets/OFF BUTTON.png';
@@ -159,6 +160,12 @@ if (mobileContactBtn) {
         contactPopupContent.scrollTop = contactPopupContent.scrollHeight;
       });
     }
+  });
+}
+
+if (mobileRestartBtn) {
+  mobileRestartBtn.addEventListener('click', () => {
+    window.location.reload();
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -810,6 +810,10 @@ body.light-mode .audio-item__progress {
   display: none;
 }
 
+#mobile-restart-btn {
+  display: none;
+}
+
 .mobile-item {
   width: 100%;
   box-sizing: border-box;
@@ -906,6 +910,26 @@ body.light-mode .audio-item__progress {
     line-height: 1.8;
     display: block;
     z-index: 1;
+  }
+
+  #mobile-restart-btn {
+    position: absolute;
+    top: calc(43% + clamp(120px, 24vw, 175px));
+    left: 50%;
+    transform: translateX(-50%);
+    display: block;
+    width: clamp(86px, 22vw, 132px);
+    background: transparent;
+    border: 0;
+    padding: 0;
+    cursor: pointer;
+    z-index: 1;
+  }
+
+  #mobile-restart-btn img {
+    width: 100%;
+    height: auto;
+    display: block;
   }
 
   #mobile-social {


### PR DESCRIPTION
### Motivation
- Permitir que el usuario en móvil recargue la página pulsando un botón visual justo debajo del texto superpuesto sobre `fondomovilfinal`.

### Description
- Se añadió un botón `#mobile-restart-btn` con la imagen `assets/restart.png` justo debajo del párrafo `#mobile-final-text` en `index.html`, se agregaron estilos en `style.css` para ocultarlo por defecto y posicionarlo/mostrarse de forma responsive en la media query móvil, y se conectó en `script.js` un manejador que llama a `window.location.reload()` al hacer click.

### Testing
- Se ejecutó `node --check script.js` y no arrojó errores (sintaxis válida).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d37942cc8c832b8068966eb0814761)