### PR TITLE
Fix mobile restart button to return users to top of page

### DIFF
--- a/script.js
+++ b/script.js
@@ -107,10 +107,22 @@ const mobileTiktokBtn = document.getElementById('mobile-tiktok-btn');
 const mobileContactBtn = document.getElementById('mobile-contact-btn');
 const mobileRestartBtn = document.getElementById('mobile-restart-btn');
 const mobileFeaturedSocialButtons = document.getElementById('mobile-featured-social-buttons');
+const mobileRestartScrollKey = 'mobile-restart-scroll-top';
 const movementToggleOn = 'assets/ON BUTTON.png';
 const movementToggleOff = 'assets/OFF BUTTON.png';
 let mobileMovementEnabled = false;
 let mobileMovementResetTarget = null;
+
+if (sessionStorage.getItem(mobileRestartScrollKey) === 'true') {
+  sessionStorage.removeItem(mobileRestartScrollKey);
+  if ('scrollRestoration' in history) {
+    history.scrollRestoration = 'manual';
+  }
+  window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+  requestAnimationFrame(() => {
+    mobileIntro?.scrollIntoView({ behavior: 'auto', block: 'start' });
+  });
+}
 
 // Ajuste de unidades vh en móviles
 function updateVh() {
@@ -165,6 +177,7 @@ if (mobileContactBtn) {
 
 if (mobileRestartBtn) {
   mobileRestartBtn.addEventListener('click', () => {
+    sessionStorage.setItem(mobileRestartScrollKey, 'true');
     window.location.reload();
   });
 }


### PR DESCRIPTION
### Motivation
- The mobile "restart" overlay button reloaded the page but preserved the previous scroll position instead of returning the user to the start of the mobile experience, so we need to force a one-time jump to the intro after a restart reload.

### Description
- In `script.js` add a one-time session flag `mobile-restart-scroll-top` set before `window.location.reload()` and on load detect and remove that flag, disable `history.scrollRestoration` and force `window.scrollTo()` and `mobileIntro.scrollIntoView()` to return the user to the page start.

### Testing
- Ran a static syntax check with `node --check script.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d37b525290832b9b6a50e694567767)