### PR TITLE
Actualizar preloader para usar assets/fondocarga.png

### DIFF
--- a/style.css
+++ b/style.css
@@ -6,11 +6,16 @@
   left: 0;
   width: 100vw;
   height: 100vh;
+  height: 100dvh;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
-  background: linear-gradient(180deg, #000 0%, #1e1e1e 50%, #000 100%);
+  background-image: url('assets/fondocarga.png');
+  background-position: center top;
+  background-repeat: no-repeat;
+  background-size: auto 100%;
+  background-color: #000;
   padding-top: 20vh;
   z-index: 10000;
 }


### PR DESCRIPTION
### Motivation
- Reemplazar el degradado de la pantalla de carga por la imagen `assets/fondocarga.png` y asegurar que la imagen encaje en altura del dispositivo permitiendo exceder el ancho si es necesario.

### Description
- Modifica `#preloader` en `style.css` para usar `background-image: url('assets/fondocarga.png')`, `background-size: auto 100%`, `background-position: center top`, `background-repeat: no-repeat`, añade `background-color: #000` y `height: 100dvh` además de `100vh`.

### Testing
- Ejecuté `git diff --check` y `git status --short` tras el cambio y no reportaron errores; el cambio fue commitado correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d38a9aa788832ba55c47a6fae906b2)