### PR TITLE
Mantener layout móvil al girar a horizontal en dispositivos táctiles

### DIFF
--- a/script.js
+++ b/script.js
@@ -11,7 +11,8 @@ import {
   tiktokProfileUrl
 } from './config.js';
 
-const isMobile = window.matchMedia('(max-width: 768px)').matches;
+const mobileMediaQuery = '(max-width: 768px), ((hover: none) and (pointer: coarse) and (orientation: landscape))';
+const isMobile = window.matchMedia(mobileMediaQuery).matches;
 
 const preloader = document.getElementById('preloader');
 const progress = document.getElementById('preloader-progress');
@@ -1169,7 +1170,7 @@ function initMobileGame() {
 }
 
 let mobileGameInitialized = false;
-const mq = window.matchMedia('(max-width: 768px)');
+const mq = window.matchMedia(mobileMediaQuery);
 
 function handleMediaQuery(e) {
   if (!mobileGame) return;

--- a/style.css
+++ b/style.css
@@ -67,7 +67,7 @@ body {
   overflow: hidden;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 768px), ((hover: none) and (pointer: coarse) and (orientation: landscape)) {
   html,
   body {
     overflow-x: hidden;
@@ -836,7 +836,7 @@ body.light-mode .audio-item__progress {
   object-fit: contain;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 768px), ((hover: none) and (pointer: coarse) and (orientation: landscape)) {
    :root {
     --popup-font-size: 16px;
     --popup-header-font-size: 16px;


### PR DESCRIPTION
### Motivation
- Evitar que al girar un teléfono a apaisado (landscape) la web pase involuntariamente a la versión de escritorio cuando el ancho supera `768px`.
- Mantener la experiencia y los estilos/funcionalidades móviles (por ejemplo el juego móvil) también en horizontal en dispositivos táctiles.

### Description
- Introduje una media query compartida `'(max-width: 768px), ((hover: none) and (pointer: coarse) and (orientation: landscape))'` para tratar como móvil tanto pantallas pequeñas como dispositivos táctiles en horizontal. 
- Apliqué esa condición en `style.css` donde había `@media (max-width: 768px)` para que los estilos móviles sigan activos al girar el dispositivo.
- Reemplacé la detección de móvil en `script.js` creando `mobileMediaQuery` y usándola en el `matchMedia` para `isMobile` y para la variable `mq` que controla el cambio entre juego móvil y versión de escritorio.

### Testing
- Ejecutado `git diff --check` y no reportó problemas (pasó).
- Ejecutado `git status --short` para verificar archivos modificados y mostró `script.js` y `style.css` (OK).
- Revisado el `git diff` de `script.js` y `style.css` para confirmar los cambios aplicados (revisión manual, OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3922868d8832b8e335100bd55ef5a)