### PR TITLE
Añade pie de texto superpuesto en la sección final móvil

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
   <div id="mobile-final">
     <img src="assets/fondomovilfinal.png" alt="Fondo final" />
     <p id="mobile-final-text">Muchas gracias por llegar hasta aquí :) <br> <br> <br> <br> Si te interesa colaborar o tienes alguna sugerencia, estaré encantado de hablar contigo</p>
+    <p id="mobile-final-footer-text">Tu texto de pie de página aquí.<br>Puedes forzar saltos de línea con &lt;br&gt; donde quieras.</p>
     <button id="mobile-restart-btn" type="button" aria-label="Recargar la página">
       <img src="assets/restart.png" alt="Recargar página" />
     </button>

--- a/style.css
+++ b/style.css
@@ -816,6 +816,10 @@ body.light-mode .audio-item__progress {
   display: none;
 }
 
+#mobile-final-footer-text {
+  display: none;
+}
+
 #mobile-restart-btn {
   display: none;
 }
@@ -916,6 +920,22 @@ body.light-mode .audio-item__progress {
     line-height: 1.8;
     display: block;
     z-index: 1;
+  }
+
+  #mobile-final-footer-text {
+    position: absolute;
+    left: 12px;
+    right: 12px;
+    bottom: max(8px, env(safe-area-inset-bottom));
+    margin: 0;
+    color: #fff;
+    text-align: left;
+    font-family: 'PixelFont', monospace;
+    font-size: clamp(8px, 2.1vw, 10px);
+    line-height: 1.35;
+    display: block;
+    z-index: 1;
+    pointer-events: none;
   }
 
   #mobile-restart-btn {


### PR DESCRIPTION
### Motivation
- Añadir un texto pequeño superpuesto en la pantalla final móvil, alineado a la izquierda y pegado al borde inferior de la imagen `fondomovilfinal`, con soporte explícito para introducir saltos de línea con `<br>`.

### Description
- Se añadió un nuevo párrafo `#mobile-final-footer-text` dentro de `#mobile-final` en `index.html` para contener el pie de página en HTML con saltos de línea manuales (`<br>`). 
- Se incorporaron reglas en `style.css` para ocultar el texto fuera de la vista móvil y, dentro del media query móvil existente, mostrarlo con `position: absolute`, `left/right` y `bottom: max(8px, env(safe-area-inset-bottom))`, tamaño de fuente reducido con `clamp()` y `pointer-events: none` para no interferir con controles.

### Testing
- Ejecuté `rg -n "mobile-final-footer-text" index.html style.css` para confirmar que el id fue añadido en ambos archivos y la búsqueda devolvió resultados satisfactores. 
- Inspeccioné las porciones afectadas con paginado (`nl`/`sed`) para verificar la inserción correcta del bloque HTML y las reglas CSS dentro del media query móvil.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d39624dee4832ba5da6deddd0df936)