### PR TITLE
Añade botones sociales en la esquina inferior derecha del bloque final móvil

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,17 @@
     <img src="assets/fondomovilfinal.png" alt="Fondo final" />
     <p id="mobile-final-text">Muchas gracias por llegar hasta aquí :) <br> <br> <br> <br> Si te interesa colaborar o tienes alguna sugerencia, estaré encantado de hablar contigo</p>
     <p id="mobile-final-footer-text"> al.one.lndlm@gmail.com <br> <br> <br> Madrid, España <br>© 2026 Al.One</p>
+    <div id="mobile-final-social-buttons">
+      <a href="https://www.tiktok.com/@al.one.wav" target="_blank" rel="noopener noreferrer" aria-label="Ir al perfil de TikTok">
+        <img src="assets/Boton TT.png" alt="Perfil de TikTok" />
+      </a>
+      <a href="https://www.instagram.com/al.one.wav/" target="_blank" rel="noopener noreferrer" aria-label="Ir al perfil de Instagram">
+        <img src="assets/Boton Insta.png" alt="Perfil de Instagram" />
+      </a>
+      <a href="https://www.youtube.com/@alonelndlm1312" target="_blank" rel="noopener noreferrer" aria-label="Ir al canal de YouTube">
+        <img src="assets/Boton YT.png" alt="Canal de YouTube" />
+      </a>
+    </div>
     <button id="mobile-restart-btn" type="button" aria-label="Recargar la página">
       <img src="assets/restart.png" alt="Recargar página" />
     </button>

--- a/style.css
+++ b/style.css
@@ -820,6 +820,10 @@ body.light-mode .audio-item__progress {
   display: none;
 }
 
+#mobile-final-social-buttons {
+  display: none;
+}
+
 #mobile-restart-btn {
   display: none;
 }
@@ -958,6 +962,28 @@ body.light-mode .audio-item__progress {
     width: 100%;
     height: auto;
     display: block;
+  }
+
+  #mobile-final-social-buttons {
+    position: absolute;
+    right: 10px;
+    bottom: calc(10px + env(safe-area-inset-bottom));
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    z-index: 2;
+  }
+
+  #mobile-final-social-buttons a {
+    display: block;
+    width: 26px;
+    line-height: 0;
+  }
+
+  #mobile-final-social-buttons img {
+    display: block;
+    width: 100%;
+    height: auto;
   }
 
   #mobile-social {


### PR DESCRIPTION
### Motivation
- Mostrar los botones de TikTok, Instagram y YouTube superpuestos sobre la imagen `fondomovilfinal` en la versión móvil, en la esquina inferior derecha con 10px de separación.

### Description
- Se añadió dentro de `#mobile-final` un contenedor `#mobile-final-social-buttons` con los enlaces e imágenes para TikTok, Instagram y YouTube.
- Se añadió una regla CSS global que oculta `#mobile-final-social-buttons` por defecto y en la media query móvil se posiciona con `position: absolute`, `right: 10px` y `bottom: calc(10px + env(safe-area-inset-bottom))` y `display: flex` para mostrar los iconos en línea horizontal.
- Los iconos se ajustan a un tamaño pequeño mediante `width: 26px` en los enlaces y `width: 100%` en las imágenes para mantener proporción y espacio (`gap: 8px`).
- Los archivos modificados son `index.html` y `style.css`.

### Testing
- Se ejecutaron las comprobaciones de coherencia del repositorio (diff/sanity) y no informaron errores.
- No hay pruebas automatizadas de interfaz visual en el repositorio, por lo que la verificación de diseño queda para revisión visual en dispositivo móvil.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d39b0a1e44832ba57d8fa42e144745)