### PR TITLE
Actualizar menú móvil superpuesto para usar texto alineado a la izquierda

### DIFF
--- a/script.js
+++ b/script.js
@@ -109,8 +109,6 @@ const mobileContactBtn = document.getElementById('mobile-contact-btn');
 const mobileRestartBtn = document.getElementById('mobile-restart-btn');
 const mobileFeaturedSocialButtons = document.getElementById('mobile-featured-social-buttons');
 const mobileRestartScrollKey = 'mobile-restart-scroll-top';
-const movementToggleOn = 'assets/ON BUTTON.png';
-const movementToggleOff = 'assets/OFF BUTTON.png';
 let mobileMovementEnabled = false;
 let mobileMovementResetTarget = null;
 
@@ -388,12 +386,8 @@ zones.forEach((zone, idx) => {
   const item = document.createElement('a');
   item.className = 'menu-link';
   item.dataset.popup = zone.id;
+  item.textContent = mobileSectionLabels[zone.id] || zone.popup?.title || zone.id;
 
-  const labelImg = document.createElement('img');
-  labelImg.src = zone.listLabel;
-  labelImg.alt = zone.id;
-
-  item.appendChild(labelImg);
   mobileMenuOverlay.appendChild(item);
 
   if (idx < zones.length - 1) {
@@ -412,19 +406,15 @@ movementToggleButton.type = 'button';
 movementToggleButton.id = 'mobile-movement-toggle';
 movementToggleButton.setAttribute('aria-pressed', 'false');
 
-const movementToggleIcon = document.createElement('img');
-movementToggleIcon.alt = 'Movimiento apagado';
-
-movementToggleButton.appendChild(movementToggleIcon);
 movementToggleRow.appendChild(movementToggleLabel);
 movementToggleRow.appendChild(movementToggleButton);
 mobileMenuOverlay.appendChild(document.createElement('hr'));
 mobileMenuOverlay.appendChild(movementToggleRow);
 
 function updateMovementToggleUI() {
-  movementToggleIcon.src = mobileMovementEnabled ? movementToggleOn : movementToggleOff;
-  movementToggleIcon.alt = mobileMovementEnabled ? 'Movimiento encendido' : 'Movimiento apagado';
+  movementToggleButton.textContent = mobileMovementEnabled ? 'Activado' : 'Desactivado';
   movementToggleButton.setAttribute('aria-pressed', mobileMovementEnabled ? 'true' : 'false');
+  movementToggleButton.setAttribute('aria-label', mobileMovementEnabled ? 'Movimiento encendido' : 'Movimiento apagado');
 }
 
 function setMobileMovementEnabled(enabled) {

--- a/style.css
+++ b/style.css
@@ -1012,7 +1012,8 @@ body.light-mode .audio-item__progress {
     display: none;
     flex-direction: column;
     justify-content: center;
-    align-items: center;
+    align-items: flex-start;
+    padding: 0 24px;
     z-index: 1500;
   }
 
@@ -1021,14 +1022,13 @@ body.light-mode .audio-item__progress {
   }
 
   #mobile-menu-overlay .menu-link {
-    width: 100%;
-    display: flex;
-    justify-content: center;
-  }
-
-  #mobile-menu-overlay .menu-link img {
-    width: 60%;
-    max-width: 300px;
+    width: min(90vw, 360px);
+    color: #fff;
+    font-family: 'PixelFont', monospace;
+    font-size: 18px;
+    text-transform: uppercase;
+    text-decoration: none;
+    text-align: left;
   }
 
   #mobile-menu-overlay .menu-movement-toggle {
@@ -1041,23 +1041,22 @@ body.light-mode .audio-item__progress {
     font-family: 'PixelFont', monospace;
     font-size: 14px;
     text-transform: uppercase;
+    text-align: left;
   }
 
   #mobile-menu-overlay .menu-movement-toggle button {
-    border: none;
+    border: 1px solid #fff;
     background: transparent;
-    padding: 0;
+    color: #fff;
+    font-family: 'PixelFont', monospace;
+    font-size: 14px;
+    text-transform: uppercase;
+    padding: 6px 10px;
     cursor: pointer;
   }
 
-  #mobile-menu-overlay .menu-movement-toggle img {
-    width: 80px;
-    height: auto;
-    display: block;
-  }
-
   #mobile-menu-overlay hr {
-    width: 100%;
+    width: min(90vw, 360px);
     border: none;
     border-top: 1px solid #fff;
     margin: 20px 0;


### PR DESCRIPTION
### Motivation
- Sustituir los iconos/imagenes del menú móvil del header por etiquetas de texto que muestren el nombre de cada sección para mejorar accesibilidad y legibilidad.
- Que el menú superpuesto quede alineado a la izquierda y con un ancho consistente por fila para mayor coherencia visual en móvil.
- Reemplazar el control gráfico de "Movimiento de Chust" por un botón textual que muestre el estado (Activado/Desactivado).

### Description
- Modifiqué `script.js` para que cada `.menu-link` se genere con `textContent` usando `mobileSectionLabels` en lugar de insertar una etiqueta `<img>`, y para que el toggle de movimiento use texto (`'Activado'`/`'Desactivado'`) y un `aria-label` en vez de iconos.
- Eliminé las referencias a los assets de botones ON/OFF y al elemento `<img>` del toggle, y actualicé la inicialización y el `updateMovementToggleUI` para manejar texto y atributos ARIA.
- Actualicé `style.css` para que `#mobile-menu-overlay` alinee el contenido a la izquierda (`align-items: flex-start`), añada padding lateral, limite el ancho de las filas (`width: min(90vw, 360px)`) y convierta `.menu-link` en elementos textuales (fuente, tamaño y alineación a la izquierda); también ajusté estilos del botón de movimiento y las reglas de `hr`.
- Archivos modificados: `script.js`, `style.css`.

### Testing
- Ejecuté la comprobación de sintaxis con `node --check script.js` y completó correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d39d2ebc24832bb9ce7552a7001050)