### PR TITLE
Ajusta interlineado y ritmo de la animación de texto en la intro móvil

### DIFF
--- a/style.css
+++ b/style.css
@@ -1115,16 +1115,16 @@ body.light-mode .audio-item__progress {
     text-align: center;
     white-space: normal;
     max-width: 90vw;
-    line-height: 1.2;
+    line-height: 1.5;
     text-shadow: #000 2px 2px;
   }
 
   .mobile-intro-typing-line {
     --line-chars: 20;
-    --typing-duration: 1.6s;
-    --typing-delay: 2s;
+    --typing-duration: 1.05s;
+    --typing-delay: 1.2s;
     display: block;
-    margin: 0 auto;
+    margin: 0.14em auto;
     width: 0;
     overflow: hidden;
     white-space: nowrap;
@@ -1137,7 +1137,7 @@ body.light-mode .audio-item__progress {
 
   .mobile-intro-typing-line--2 {
     --line-chars: 22;
-    --typing-delay: 3.7s;
+    --typing-delay: 2.35s;
   }
 
   #mobile-featured-social-buttons {


### PR DESCRIPTION
### Motivation
- Mejorar la legibilidad separando verticalmente las dos líneas del texto animado en la intro móvil.
- Hacer que la animación de tipeo ocupe menos tiempo para que el texto aparezca más rápido al cargar la página.
- Evitar solapamientos durante la animación añadiendo un pequeño margen entre líneas.

### Description
- Se aumentó `line-height` en `#mobile-intro-typing` de `1.2` a `1.5` en `style.css`.
- En `.mobile-intro-typing-line` se redujo `--typing-duration` de `1.6s` a `1.05s`, se adelantó `--typing-delay` de `2s` a `1.2s` y se cambió `margin` de `0 auto` a `0.14em auto`.
- En `.mobile-intro-typing-line--2` se ajustó `--typing-delay` de `3.7s` a `2.35s`.
- Todos los cambios se aplicaron en `style.css` y fueron commitados al repositorio.

### Testing
- No existe una suite de tests automáticos para este repositorio que verifique cambios visuales en CSS.
- Se verificó el contenido del fichero con `nl -ba style.css | sed -n '1100,1150p'` y se buscó la ubicación con `rg`, y ambos comandos completaron con éxito.
- El cambio fue commitado con `git commit` exitosamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3a2287f40832b9538cab06a2adcf7)