### PR TITLE
Refactoriza bloques de contenido editable para Trabajos y Música

### DIFF
--- a/config.js
+++ b/config.js
@@ -15,6 +15,112 @@ export const tiktokProfileUrl = 'https://www.tiktok.com/@al.one.wav';
 // URL del perfil de Instagram (úsala para el botón destacado en móvil)
 export const instagramProfileUrl = 'https://www.instagram.com/al.one.wav/';
 
+// =============================
+//  CONTENIDO EDITABLE (v1.0)
+// =============================
+// 1) Trabajos (álbumes + canciones)
+// 2) Música (desplegables: Instrumentales, Experimentos, Covers)
+//
+// Para añadir nuevos bloques, copia/pega un objeto y cambia thumb, title, url, etc.
+
+export const trabajosAlbums = [
+  {
+    album: {
+      title: 'El Niño y Su Fe - Guiber & Al.One',
+      url: 'https://www.youtube.com/watch?v=9gNmEuoKf7c&list=RD9gNmEuoKf7c&start_radio=1',
+      thumb: 'assets/mini1.jpg',
+      description: '"El Niño y Su Fe" es una obra híbrida que nace entre la música y la imagen. Un "albumetraje": un proyecto que utiliza el lenguaje del álbum musical para construir una narración audiovisual continua, donde cada canción es una escena. El proyecto explora la memoria, la pérdida y la fe entendida no como religión, sino como aquello en lo que uno se apoya cuando todo lo demás empieza a fallar. A través de una mirada íntima y fragmentada, la obra dialoga con la infancia, la familia y el paso del tiempo, construyendo un relato emocional que avanza más por sensaciones que por respuestas. No es solo un trabajo musical ni únicamente una pieza audiovisual. Es un intento de dar forma a lo que permanece, incluso cuando la memoria se deshilacha.'
+    },
+    songs: [
+      { title: '1. Gama Ocre', url: 'https://youtu.be/gjnF2xA8EgU?si=-Lz4cv3UeemV82s7', thumb: 'assets/MINI 2.jpg' },
+      { title: '2. Chicos Malos Buenos Tipos', url: 'https://youtu.be/olTjbh7295U?si=6XDtN3jbhnOMuLol', thumb: 'assets/MINI 3.jpg' },
+      { title: '3. Los Penúltimos Versos Que Te Escribo', url: 'https://youtu.be/w4X0c4Csqck?si=phNUqeIYaCTdfJEB', thumb: 'assets/MINI 4.jpg' },
+      { title: '4. El Niño y Su Fe', url: 'https://youtu.be/iBjQlLn3eGI?si=11dlDPzwzun_HKG5', thumb: 'assets/MINI 5.jpg' },
+      { title: '5. Mi Negra Tomasa', url: 'https://youtu.be/E5ZnLgfJucQ?si=sVSPpSJ5IDL6jNVH', thumb: 'assets/MINI 6.jpg' },
+      { title: '6. Continental 67´', url: 'https://youtu.be/N-r1HKcgNl8?si=Sl-_nix8Xwfa8e34', thumb: 'assets/MINI 7.jpg' },
+      { title: '7. Xyla', url: 'https://youtu.be/9To2SQiQXKE?si=Nqrg5c2J_sX0-M4l', thumb: 'assets/MINI 8.jpg' }
+    ]
+  },
+  {
+    album: {
+      title: 'TDB (Tierra De Barros) - Marker T & Al.One',
+      url: 'https://youtu.be/qGOawjmFM8A?si=CpSVPV51H_c76tt9',
+      thumb: 'assets/TDB0.webp',
+      divider: true,
+      description: '"Tierra de Barros" (TDB) es un álbum debut muy personal que explora la identidad de Marker-T desde su relación con la tierra que lo vio crecer: Extremadura. Un proyecto que entiende el territorio no solo como un lugar físico, sino como memoria, carácter y forma de estar en el mundo. El álbum mezcla los códigos del hip-hop con elementos culturales propios de la tierra extremeña, incorporando samples y referencias a figuras representativas de su música tradicional. El resultado es un diálogo entre lo contemporáneo y lo heredado, entre el ritmo urbano y el peso de la raíz. TDB construye una identidad de hip-hop extremeño honesta y cuidada, donde la experiencia personal se convierte en discurso colectivo. Un álbum que habla desde la tierra, sin folclore impostado, y que reivindica el origen como parte esencial del sonido.'
+    },
+    songs: [
+      { title: '1. El Miajón', url: 'https://youtu.be/r7v66L14CIY?si=i29TWJnDchiaF02K', thumb: 'assets/TDB5.jpg' },
+      { title: '2. LXXL', url: 'https://youtu.be/qrz6GHOQeWo?si=G3NDKIrxeIGsKGWG', thumb: 'assets/TDB1.jpg' },
+      { title: '3. MID00´S', url: 'https://youtu.be/VoGZL0BbisA?si=O8v8NPwVlMLQr_QL', thumb: 'assets/TDB2.webp' },
+      { title: '4. DETROIT 89´', url: 'https://youtu.be/TCTaVd1pkNU?si=FIcTLrw6MaOrvbLk', thumb: 'assets/TDB3.webp' },
+      { title: '5. WUTW', url: 'https://youtu.be/1bG2_86Cqzk?si=KlASDkXCWNGy3NUz', thumb: 'assets/TDB4.webp' }
+    ]
+  }
+];
+
+export const musicDropdownSections = [
+  {
+    id: 'instrumentales',
+    title: 'Instrumentales',
+    frameImage: 'assets/contenedor música inst.png',
+    items: []
+    // Ejemplo de item:
+    // { title: 'Título instrumental', url: 'https://...', thumb: 'assets/tu-thumb.png', description: 'Opcional' }
+  },
+  {
+    id: 'experimentos',
+    title: 'Experimentos',
+    frameImage: 'assets/contenedor música exp.png',
+    items: []
+  },
+  {
+    id: 'covers',
+    title: 'Covers',
+    frameImage: 'assets/contenedor música cov.png',
+    items: []
+  }
+];
+
+function renderWorkSongsRow(songs) {
+  return `
+    <div class="work-songs-row">
+      ${songs
+        .map(song => `
+          <div class="work-song">
+            <a class="thumb-link" href="${song.url}" target="_blank">
+              <img class="thumb" src="${song.thumb}" alt="${song.title}">
+            </a>
+            <a class="title-link" href="${song.url}" target="_blank">${song.title}</a>
+          </div>
+        `)
+        .join('')}
+    </div>
+  `;
+}
+
+function renderWorkAlbumBlock(albumEntry) {
+  const album = albumEntry.album;
+  return `
+    <div class="work-album ${album.divider ? 'album-divider' : ''}">
+      <a class="album-link" href="${album.url}" target="_blank">
+        <img class="thumb" src="${album.thumb}" alt="${album.title}">
+      </a>
+      <div class="info">
+        <h3><a class="album-link" href="${album.url}" target="_blank">${album.title}</a></h3>
+        <p class="album-description">${album.description}</p>
+      </div>
+    </div>
+    ${renderWorkSongsRow(albumEntry.songs)}
+  `;
+}
+
+export const trabajosPopupContent = `
+  <div class="trabajos-gallery">
+    ${trabajosAlbums.map(renderWorkAlbumBlock).join('')}
+  </div>
+`;
+
 // Definición de zonas interactivas y su contenido emergente
 export const zones = [
   {
@@ -38,122 +144,13 @@ export const zones = [
     position: { top: '3.7vh', right: '4.7vw' },
     popup: {
       title: 'Trabajos',
-      content: `
-        <div class="trabajos-gallery">
-          <!-- Álbum 1 -->
-          <div class="work-album">
-            <a class="album-link" href="https://www.youtube.com/watch?v=9gNmEuoKf7c&list=RD9gNmEuoKf7c&start_radio=1" target="_blank">
-              <img class="thumb" src="assets/mini1.jpg" alt="Álbum 1">
-            </a>
-            <div class="info">
-              <h3><a class="album-link" href="https://www.youtube.com/watch?v=9gNmEuoKf7c&list=RD9gNmEuoKf7c&start_radio=1" target="_blank">El Niño y Su Fe - Guiber & Al.One</a></h3>
-              <p class="album-description">"El Niño y Su Fe" es una obra híbrida que nace entre la música y la imagen. Un "albumetraje": un proyecto que utiliza el lenguaje del álbum musical para construir una narración audiovisual continua, donde cada canción es una escena.
-              El proyecto explora la memoria, la pérdida y la fe entendida no como religión, sino como aquello en lo que uno se apoya cuando todo lo demás empieza a fallar. A través de una mirada íntima y fragmentada, la obra dialoga con la infancia, la familia y el paso del tiempo, construyendo un relato emocional que avanza más por sensaciones que por respuestas.
-              No es solo un trabajo musical ni únicamente una pieza audiovisual. Es un intento de dar forma a lo que permanece, incluso cuando la memoria se deshilacha.</p>
-            </div>
-          </div>
-
-          <!-- Canciones del Álbum 1 -->
-          <div class="work-songs-row">
-            <div class="work-song">
-              <a class="thumb-link" href="https://youtu.be/gjnF2xA8EgU?si=-Lz4cv3UeemV82s7" target="_blank">
-                <img class="thumb" src="assets/MINI 2.jpg" alt="Canción 1">
-              </a>
-              <a class="title-link" href="https://youtu.be/gjnF2xA8EgU?si=-Lz4cv3UeemV82s7" target="_blank">1. Gama Ocre</a>
-            </div>
-            <div class="work-song">
-              <a class="thumb-link" href="https://youtu.be/olTjbh7295U?si=6XDtN3jbhnOMuLol" target="_blank">
-                <img class="thumb" src="assets/MINI 3.jpg" alt="Canción 2">
-              </a>
-              <a class="title-link" href="https://youtu.be/olTjbh7295U?si=6XDtN3jbhnOMuLol" target="_blank">2. Chicos Malos Buenos Tipos</a>
-            </div>
-            <div class="work-song">
-              <a class="thumb-link" href="https://youtu.be/w4X0c4Csqck?si=phNUqeIYaCTdfJEB" target="_blank">
-                <img class="thumb" src="assets/MINI 4.jpg" alt="Canción 2">
-              </a>
-              <a class="title-link" href="https://youtu.be/w4X0c4Csqck?si=phNUqeIYaCTdfJEB" target="_blank">3. Los Penúltimos Versos Que Te Escribo</a>
-            </div>
-            <div class="work-song">
-              <a class="thumb-link" href="https://youtu.be/iBjQlLn3eGI?si=11dlDPzwzun_HKG5" target="_blank">
-                <img class="thumb" src="assets/MINI 5.jpg" alt="Canción 2">
-              </a>
-              <a class="title-link" href="https://youtu.be/iBjQlLn3eGI?si=11dlDPzwzun_HKG5" target="_blank">4. El Niño y Su Fe</a>
-            </div>
-            <div class="work-song">
-              <a class="thumb-link" href="https://youtu.be/E5ZnLgfJucQ?si=sVSPpSJ5IDL6jNVH" target="_blank">
-                <img class="thumb" src="assets/MINI 6.jpg" alt="Canción 2">
-              </a>
-              <a class="title-link" href="https://youtu.be/E5ZnLgfJucQ?si=sVSPpSJ5IDL6jNVH" target="_blank">5. Mi Negra Tomasa</a>
-            </div>
-            <div class="work-song">
-              <a class="thumb-link" href="https://youtu.be/N-r1HKcgNl8?si=Sl-_nix8Xwfa8e34" target="_blank">
-                <img class="thumb" src="assets/MINI 7.jpg" alt="Canción 2">
-              </a>
-              <a class="title-link" href="https://youtu.be/N-r1HKcgNl8?si=Sl-_nix8Xwfa8e34" target="_blank">6. Continental 67´</a>
-            </div>
-            <div class="work-song">
-              <a class="thumb-link" href="https://youtu.be/9To2SQiQXKE?si=Nqrg5c2J_sX0-M4l" target="_blank">
-                <img class="thumb" src="assets/MINI 8.jpg" alt="Canción 2">
-              </a>
-              <a class="title-link" href="https://youtu.be/9To2SQiQXKE?si=Nqrg5c2J_sX0-M4l" target="_blank">7. Xyla</a>
-            </div>
-          </div>
-
-          <!-- Álbum 2 -->
-          <div class="work-album album-divider">
-            <a class="album-link" href="https://youtu.be/qGOawjmFM8A?si=CpSVPV51H_c76tt9" target="_blank">
-              <img class="thumb" src="assets/TDB0.webp" alt="Álbum 2">
-            </a>
-            <div class="info">
-              <h3><a class="album-link" href="https://youtu.be/qGOawjmFM8A?si=CpSVPV51H_c76tt9" target="_blank">TDB (Tierra De Barros) - Marker T & Al.One</a></h3>
-              <p class="album-description">"Tierra de Barros" (TDB) es un álbum debut muy personal que explora la identidad de Marker-T desde su relación con la tierra que lo vio crecer: Extremadura. Un proyecto que entiende el territorio no solo como un lugar físico, sino como memoria, carácter y forma de estar en el mundo.
-              El álbum mezcla los códigos del hip-hop con elementos culturales propios de la tierra extremeña, incorporando samples y referencias a figuras representativas de su música tradicional. El resultado es un diálogo entre lo contemporáneo y lo heredado, entre el ritmo urbano y el peso de la raíz.
-              TDB construye una identidad de hip-hop extremeño honesta y cuidada, donde la experiencia personal se convierte en discurso colectivo. Un álbum que habla desde la tierra, sin folclore impostado, y que reivindica el origen como parte esencial del sonido.</p>
-            </div>
-          </div>
-
-          <!-- Canciones del Álbum 2 -->
-          <div class="work-songs-row">
-            <div class="work-song">
-              <a class="thumb-link" href="https://youtu.be/r7v66L14CIY?si=i29TWJnDchiaF02K" target="_blank">
-                <img class="thumb" src="assets/TDB5.jpg" alt="Canción A">
-              </a>
-              <a class="title-link" href="https://youtu.be/r7v66L14CIY?si=i29TWJnDchiaF02K" target="_blank">1. El Miajón</a>
-            </div>
-            <div class="work-song">
-              <a class="thumb-link" href="https://youtu.be/qrz6GHOQeWo?si=G3NDKIrxeIGsKGWG" target="_blank">
-                <img class="thumb" src="assets/TDB1.jpg" alt="Canción B">
-              </a>
-              <a class="title-link" href="https://youtu.be/qrz6GHOQeWo?si=G3NDKIrxeIGsKGWG" target="_blank">2. LXXL</a>
-            </div>
-            <div class="work-song">
-              <a class="thumb-link" href="https://youtu.be/VoGZL0BbisA?si=O8v8NPwVlMLQr_QL" target="_blank">
-                <img class="thumb" src="assets/TDB2.webp" alt="Canción A">
-              </a>
-              <a class="title-link" href="https://youtu.be/VoGZL0BbisA?si=O8v8NPwVlMLQr_QL" target="_blank">3. MID00´S</a>
-            </div>
-            <div class="work-song">
-              <a class="thumb-link" href="https://youtu.be/TCTaVd1pkNU?si=FIcTLrw6MaOrvbLk" target="_blank">
-                <img class="thumb" src="assets/TDB3.webp" alt="Canción A">
-              </a>
-              <a class="title-link" href="https://youtu.be/TCTaVd1pkNU?si=FIcTLrw6MaOrvbLk" target="_blank">4. DETROIT 89´</a>
-            </div>
-            <div class="work-song">
-              <a class="thumb-link" href="https://youtu.be/1bG2_86Cqzk?si=KlASDkXCWNGy3NUz" target="_blank">
-                <img class="thumb" src="assets/TDB4.webp" alt="Canción A">
-              </a>
-              <a class="title-link" href="https://youtu.be/1bG2_86Cqzk?si=KlASDkXCWNGy3NUz" target="_blank">5. WUTW</a>
-            </div>
-          </div>
-
-          </div>
-        `,
-        bg: 'assets/fondo.png',
-        gradient: 'linear-gradient(to bottom, rgba(94, 94, 94, 1), rgba(232, 232, 232, 1))'
-      }
-    },
-    {
-      id: 'contacto',
+      content: trabajosPopupContent,
+      bg: 'assets/fondo.png',
+      gradient: 'linear-gradient(to bottom, rgba(94, 94, 94, 1), rgba(232, 232, 232, 1))'
+    }
+  },
+  {
+    id: 'contacto',
     img: 'assets/Edificio3.png',
     listLabel: 'assets/text3.png',
     mobileButton: 'assets/Boton CTC.png',
@@ -211,28 +208,28 @@ export const zones = [
           </div>
           </div>
         `,
-        bg: 'assets/fondo.png',
-        gradient: 'linear-gradient(to bottom, rgba(0, 132, 255, 1), rgba(0, 0, 0, 1))'
-      }
-    },
-    {
-      id: 'plugins',
+      bg: 'assets/fondo.png',
+      gradient: 'linear-gradient(to bottom, rgba(0, 132, 255, 1), rgba(0, 0, 0, 1))'
+    }
+  },
+  {
+    id: 'plugins',
     img: 'assets/EDIFICIO2.png',
     listLabel: 'assets/text4.png',
     mobileButton: 'assets/Boton PGN.png',
     position: { bottom: '10vh', right: '4.8vw' },
-      popup: {
-        title: 'Plugins',
-        content:
-          '<p style="white-space: pre-line; font-size: 0.85em; text-align: center; opacity: 0.85; line-height: 1.6; color: white;">Estoy desarrollando algunas herramientas como parte de mi propio proceso creativo.\n\nPronto estarán disponibles en esta sección para quien quiera utilizarlas.\n\nSi te interesa, estate atent@</p>'+
-          '<img src="assets/FLECHA.png" style="display: block; margin: 20px auto 0 auto; width: 10vw;">'+ 
-          '<img src="assets/Prox.png" style="display: block; margin: 20px auto 0 auto; width: 70vw;">'+
-          '<img src="assets/Prox.png" style="display: block; margin: 20px auto 0 auto; width: 70vw;">',       
-        bg: 'assets/fondo.png',
-        gradient: 'linear-gradient(to top, rgba(0, 0, 0, 1), #7d461d)'
-      }
+    popup: {
+      title: 'Plugins',
+      content:
+        '<p style="white-space: pre-line; font-size: 0.85em; text-align: center; opacity: 0.85; line-height: 1.6; color: white;">Estoy desarrollando algunas herramientas como parte de mi propio proceso creativo.\n\nPronto estarán disponibles en esta sección para quien quiera utilizarlas.\n\nSi te interesa, estate atent@</p>' +
+        '<img src="assets/FLECHA.png" style="display: block; margin: 20px auto 0 auto; width: 10vw;">' +
+        '<img src="assets/Prox.png" style="display: block; margin: 20px auto 0 auto; width: 70vw;">' +
+        '<img src="assets/Prox.png" style="display: block; margin: 20px auto 0 auto; width: 70vw;">',
+      bg: 'assets/fondo.png',
+      gradient: 'linear-gradient(to top, rgba(0, 0, 0, 1), #7d461d)'
     }
-  ];
+  }
+];
 
 // Últimos trabajos destacados para el carrusel móvil
 export const mobileLatestWorks = [

--- a/script.js
+++ b/script.js
@@ -8,7 +8,8 @@ import {
   mobileLatestWorks,
   youtubeChannelUrl,
   instagramProfileUrl,
-  tiktokProfileUrl
+  tiktokProfileUrl,
+  musicDropdownSections
 } from './config.js';
 
 const mobileMediaQuery = '(max-width: 768px), ((hover: none) and (pointer: coarse) and (orientation: landscape))';
@@ -868,28 +869,10 @@ function resetMobileMusicPopup() {
   introArrow.src = 'assets/FLECHA.png';
   introArrow.alt = 'Flecha decorativa';
 
-  const musicSections = [
-    {
-      id: 'instrumentales',
-      title: 'Instrumentales',
-      frameImage: 'assets/contenedor música inst.png'
-    },
-    {
-      id: 'experimentos',
-      title: 'Experimentos',
-      frameImage: 'assets/contenedor música exp.png'
-    },
-    {
-      id: 'covers',
-      title: 'Covers',
-      frameImage: 'assets/contenedor música cov.png'
-    }
-  ];
-
   const wrapper = document.createElement('div');
   wrapper.className = 'mobile-music-dropdowns';
 
-  musicSections.forEach(section => {
+  musicDropdownSections.forEach(section => {
     const dropdown = document.createElement('details');
     dropdown.className = 'mobile-music-dropdown';
     dropdown.dataset.section = section.id;
@@ -901,7 +884,20 @@ function resetMobileMusicPopup() {
 
     const content = document.createElement('div');
     content.className = 'mobile-music-dropdown__content';
-    content.innerHTML = '<p class="mobile-music-dropdown__placeholder">Próximamente…</p>';
+
+    if (!section.items || section.items.length === 0) {
+      content.innerHTML = '<p class="mobile-music-dropdown__placeholder">Próximamente…</p>';
+    } else {
+      content.innerHTML = section.items
+        .map(item => `
+          <article class="mobile-music-item">
+            ${item.thumb ? `<a class="mobile-music-item__thumb-link" href="${item.url}" target="_blank"><img class="mobile-music-item__thumb" src="${item.thumb}" alt="${item.title}"></a>` : ''}
+            <a class="mobile-music-item__title" href="${item.url}" target="_blank">${item.title}</a>
+            ${item.description ? `<p class="mobile-music-item__description">${item.description}</p>` : ''}
+          </article>
+        `)
+        .join('');
+    }
 
     dropdown.appendChild(summary);
     dropdown.appendChild(content);


### PR DESCRIPTION
### Motivation
- Centralizar el contenido editable para facilitar añadir/editar álbumes y entradas de música sin tocar HTML disperso. 
- Separar datos de presentación para que los bloques repetibles (álbumes, canciones, ítems de música) sean copiables y mantenibles en un único fichero de configuración.

### Description
- Añade en `config.js` la sección `CONTENIDO EDITABLE (v1.0)` con `trabajosAlbums` (estructura de álbumes + canciones) y `musicDropdownSections` (desplegables: Instrumentales, Experimentos, Covers). 
- Implementa las funciones `renderWorkSongsRow`, `renderWorkAlbumBlock` y la constante `trabajosPopupContent` para generar el HTML de la galería de `Trabajos` a partir de `trabajosAlbums` en lugar de HTML embebido. 
- Actualiza `zones` en `config.js` para usar `trabajosPopupContent` como contenido del popup de `Trabajos` y mantiene los popups existentes de `Contacto` y `Plugins`. 
- Modifica `script.js` para importar `musicDropdownSections` y reconstruir dinámicamente los desplegables móviles de Música en `resetMobileMusicPopup`, mostrando `Próximamente…` cuando no haya ítems y renderizando artículos cuando haya elementos en `section.items`.

### Testing
- Ejecuté `node --check config.js` y la comprobación de sintaxis devolvió éxito. 
- Ejecuté `node --check script.js` y la comprobación de sintaxis devolvió éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3ecee04b4832bbd9b48760c477f52)