### PR TITLE
Agregar bloques vacíos editables a los desplegables de Música

### DIFF
--- a/config.js
+++ b/config.js
@@ -64,21 +64,49 @@ export const musicDropdownSections = [
     id: 'instrumentales',
     title: 'Instrumentales',
     frameImage: 'assets/contenedor música inst.png',
-    items: []
-    // Ejemplo de item:
-    // { title: 'Título instrumental', url: 'https://...', thumb: 'assets/tu-thumb.png', description: 'Opcional' }
+    template: {
+      type: 'audio'
+    },
+    items: [
+      {
+        title: '',
+        assetPath: 'assets/beat1.wav'
+      }
+    ]
   },
   {
     id: 'experimentos',
     title: 'Experimentos',
     frameImage: 'assets/contenedor música exp.png',
-    items: []
+    template: {
+      type: 'rich'
+    },
+    items: [
+      {
+        title: '',
+        text: '',
+        imagePath: '',
+        audioPath: '',
+        url: ''
+      }
+    ]
   },
   {
     id: 'covers',
     title: 'Covers',
     frameImage: 'assets/contenedor música cov.png',
-    items: []
+    template: {
+      type: 'rich'
+    },
+    items: [
+      {
+        title: '',
+        text: '',
+        imagePath: '',
+        audioPath: '',
+        url: ''
+      }
+    ]
   }
 ];
 

--- a/script.js
+++ b/script.js
@@ -432,10 +432,8 @@ movementToggleButton.addEventListener('click', () => {
   setMobileMovementEnabled(!mobileMovementEnabled);
 });
 
-// Reiniciar la sección de música en móvil para reconstruirla desde cero
-if (isMobile) {
-  resetMobileMusicPopup();
-}
+// Reiniciar la sección de música para reconstruirla desde cero
+resetMobileMusicPopup();
 
 // Abrir ventana al hacer click en una zona
 zonesContainer.addEventListener('click', e => {
@@ -849,6 +847,81 @@ window.addEventListener('popstate', e => {
   }
 });
 
+function renderInstrumentalTemplate(item) {
+  const safeTitle = item.title || 'Sin título';
+  const safeAssetPath = item.assetPath || '';
+  const audioMarkup = safeAssetPath
+    ? `<audio controls preload="metadata" src="${safeAssetPath}"></audio>`
+    : '<p class="music-placeholder-note">Añade una ruta en <code>assetPath</code> para habilitar el reproductor.</p>';
+
+  return `
+    <article class="music-template-card music-template-card--audio">
+      <label class="music-template-field">
+        <span class="music-template-label">Título</span>
+        <input type="text" value="${safeTitle === 'Sin título' ? '' : safeTitle}" placeholder="Escribe un título para la instrumental">
+      </label>
+      <label class="music-template-field">
+        <span class="music-template-label">Audio (assets)</span>
+        <input type="text" value="${safeAssetPath}" placeholder="assets/tu-instrumental.wav">
+      </label>
+      <div class="music-template-player">
+        ${audioMarkup}
+      </div>
+    </article>
+  `;
+}
+
+function renderRichTemplate(item) {
+  return `
+    <article class="music-template-card music-template-card--rich">
+      <label class="music-template-field">
+        <span class="music-template-label">Título</span>
+        <input type="text" value="${item.title || ''}" placeholder="Título del bloque">
+      </label>
+      <label class="music-template-field">
+        <span class="music-template-label">Texto</span>
+        <textarea rows="3" placeholder="Descripción o texto libre">${item.text || ''}</textarea>
+      </label>
+      <label class="music-template-field">
+        <span class="music-template-label">Imagen (ruta)</span>
+        <input type="text" value="${item.imagePath || ''}" placeholder="assets/tu-imagen.png">
+      </label>
+      <label class="music-template-field">
+        <span class="music-template-label">Audio (ruta)</span>
+        <input type="text" value="${item.audioPath || ''}" placeholder="assets/tu-audio.wav">
+      </label>
+      <label class="music-template-field">
+        <span class="music-template-label">URL</span>
+        <input type="text" value="${item.url || ''}" placeholder="https://...">
+      </label>
+    </article>
+  `;
+}
+
+function renderMusicSectionContent(section) {
+  if (!section.items || section.items.length === 0) {
+    return '<p class="mobile-music-dropdown__placeholder">Próximamente…</p>';
+  }
+
+  if (section.template?.type === 'audio') {
+    return section.items.map(renderInstrumentalTemplate).join('');
+  }
+
+  if (section.template?.type === 'rich') {
+    return section.items.map(renderRichTemplate).join('');
+  }
+
+  return section.items
+    .map(item => `
+      <article class="mobile-music-item">
+        ${item.thumb ? `<a class="mobile-music-item__thumb-link" href="${item.url}" target="_blank"><img class="mobile-music-item__thumb" src="${item.thumb}" alt="${item.title}"></a>` : ''}
+        <a class="mobile-music-item__title" href="${item.url}" target="_blank">${item.title}</a>
+        ${item.description ? `<p class="mobile-music-item__description">${item.description}</p>` : ''}
+      </article>
+    `)
+    .join('');
+}
+
 function resetMobileMusicPopup() {
   const container = document.querySelector('#popup-instrumentales .popup-content');
   if (!container) return;
@@ -885,19 +958,7 @@ function resetMobileMusicPopup() {
     const content = document.createElement('div');
     content.className = 'mobile-music-dropdown__content';
 
-    if (!section.items || section.items.length === 0) {
-      content.innerHTML = '<p class="mobile-music-dropdown__placeholder">Próximamente…</p>';
-    } else {
-      content.innerHTML = section.items
-        .map(item => `
-          <article class="mobile-music-item">
-            ${item.thumb ? `<a class="mobile-music-item__thumb-link" href="${item.url}" target="_blank"><img class="mobile-music-item__thumb" src="${item.thumb}" alt="${item.title}"></a>` : ''}
-            <a class="mobile-music-item__title" href="${item.url}" target="_blank">${item.title}</a>
-            ${item.description ? `<p class="mobile-music-item__description">${item.description}</p>` : ''}
-          </article>
-        `)
-        .join('');
-    }
+    content.innerHTML = renderMusicSectionContent(section);
 
     dropdown.appendChild(summary);
     dropdown.appendChild(content);

--- a/style.css
+++ b/style.css
@@ -758,6 +758,67 @@ body.light-mode .audio-item__play-btn {
   color: inherit;
 }
 
+.music-template-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 10px 0;
+  padding: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: rgba(0, 0, 0, 0.45);
+}
+
+.music-template-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.music-template-label {
+  font-size: 12px;
+  opacity: 0.9;
+}
+
+.music-template-field input,
+.music-template-field textarea {
+  width: 100%;
+  border: 1px dashed rgba(255, 255, 255, 0.65);
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  font-family: inherit;
+  font-size: 13px;
+  line-height: 1.35;
+  padding: 8px;
+  box-sizing: border-box;
+}
+
+.music-template-field textarea {
+  resize: vertical;
+  min-height: 80px;
+}
+
+.music-template-player audio {
+  width: 100%;
+}
+
+.music-placeholder-note {
+  margin: 0;
+  font-size: 12px;
+  opacity: 0.85;
+}
+
+body.light-mode .music-template-card {
+  background: rgba(255, 255, 255, 0.55);
+  border-color: rgba(0, 0, 0, 0.25);
+}
+
+body.light-mode .music-template-field input,
+body.light-mode .music-template-field textarea {
+  background: rgba(255, 255, 255, 0.8);
+  color: #111;
+  border-color: rgba(0, 0, 0, 0.45);
+}
+
 body.light-mode .audio-item__progress {
   border-color: rgba(0, 0, 0, 0.35);
   background: repeating-linear-gradient(


### PR DESCRIPTION
### Motivation
- Añadir elementos de prueba en cada contenedor desplegable de la sección de Música para poder insertar audios desde `assets`, títulos y bloques ricos (imagen/texto/audio/URL) que el autor rellenará y estilizará después.

### Description
- Añadí plantillas y elementos placeholder en `config.js` para `instrumentales` (tipo `audio` con `assetPath`) y para `experimentos` y `covers` (tipo `rich` con campos vacíos para título, texto, imagen, audio y URL). 
- Implementé renderizado basado en plantillas en `script.js` con las funciones `renderInstrumentalTemplate`, `renderRichTemplate` y `renderMusicSectionContent`, y reconstruyo el contenido de la sección de música al cargar para que los bloques de prueba aparezcan en todos los contextos. 
- El bloque de instrumentales incluye un reproductor nativo `<audio controls>` para reproducción, visualización de duración y seek, y los bloques “rich” exponen campos editables (inputs/textarea) listos para completar. 
- Añadí estilos base en `style.css` (`.music-template-card`, campos, player y variantes modo claro/oscuro) para que las tarjetas tengan una presentación inicial y sean fáciles de ajustar estéticamente.

### Testing
- Ejecutado `node --check script.js` y el chequeo ha finalizado correctamente. 
- Ejecutado `node --check config.js` y el chequeo ha finalizado correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3f1283370832ba93298f6cd136681)