### PR TITLE
Instrumentales: reproductor personalizado y título gestionado desde código

### DIFF
--- a/config.js
+++ b/config.js
@@ -69,7 +69,7 @@ export const musicDropdownSections = [
     },
     items: [
       {
-        title: '',
+        title: 'Beat 1',
         assetPath: 'assets/beat1.wav'
       }
     ]

--- a/script.js
+++ b/script.js
@@ -848,27 +848,89 @@ window.addEventListener('popstate', e => {
 });
 
 function renderInstrumentalTemplate(item) {
-  const safeTitle = item.title || 'Sin título';
+  const safeTitle = item.title?.trim() || 'Sin título';
   const safeAssetPath = item.assetPath || '';
   const audioMarkup = safeAssetPath
-    ? `<audio controls preload="metadata" src="${safeAssetPath}"></audio>`
+    ? `
+      <div class="instrumental-player" data-instrumental-player>
+        <button type="button" class="instrumental-player__button" data-role="toggle" aria-label="Reproducir instrumental">▶</button>
+        <input
+          class="instrumental-player__timeline"
+          data-role="timeline"
+          type="range"
+          min="0"
+          max="100"
+          step="0.1"
+          value="0"
+          aria-label="Línea de tiempo de la instrumental"
+        >
+        <audio preload="metadata" src="${safeAssetPath}" data-role="audio"></audio>
+      </div>
+    `
     : '<p class="music-placeholder-note">Añade una ruta en <code>assetPath</code> para habilitar el reproductor.</p>';
 
   return `
     <article class="music-template-card music-template-card--audio">
-      <label class="music-template-field">
-        <span class="music-template-label">Título</span>
-        <input type="text" value="${safeTitle === 'Sin título' ? '' : safeTitle}" placeholder="Escribe un título para la instrumental">
-      </label>
-      <label class="music-template-field">
-        <span class="music-template-label">Audio (assets)</span>
-        <input type="text" value="${safeAssetPath}" placeholder="assets/tu-instrumental.wav">
-      </label>
+      <h4 class="music-template-title">${safeTitle}</h4>
       <div class="music-template-player">
         ${audioMarkup}
       </div>
     </article>
   `;
+}
+
+function initializeInstrumentalPlayers(container = document) {
+  const players = container.querySelectorAll('[data-instrumental-player]');
+
+  players.forEach(player => {
+    const audio = player.querySelector('[data-role="audio"]');
+    const toggleButton = player.querySelector('[data-role="toggle"]');
+    const timeline = player.querySelector('[data-role="timeline"]');
+    if (!audio || !toggleButton || !timeline) return;
+
+    const updateToggleButton = () => {
+      const isPlaying = !audio.paused;
+      toggleButton.textContent = isPlaying ? '❚❚' : '▶';
+      toggleButton.setAttribute('aria-label', isPlaying ? 'Pausar instrumental' : 'Reproducir instrumental');
+    };
+
+    const updateTimeline = () => {
+      if (!Number.isFinite(audio.duration) || audio.duration <= 0) {
+        timeline.value = '0';
+        return;
+      }
+      const progress = (audio.currentTime / audio.duration) * 100;
+      timeline.value = String(progress);
+    };
+
+    toggleButton.addEventListener('click', () => {
+      if (audio.paused) {
+        audio.play().catch(() => {
+          // Ignorar errores de reproducción automática.
+        });
+      } else {
+        audio.pause();
+      }
+    });
+
+    timeline.addEventListener('input', () => {
+      if (!Number.isFinite(audio.duration) || audio.duration <= 0) return;
+      const targetTime = (Number(timeline.value) / 100) * audio.duration;
+      audio.currentTime = targetTime;
+    });
+
+    audio.addEventListener('timeupdate', updateTimeline);
+    audio.addEventListener('loadedmetadata', updateTimeline);
+    audio.addEventListener('play', updateToggleButton);
+    audio.addEventListener('pause', updateToggleButton);
+    audio.addEventListener('ended', () => {
+      updateToggleButton();
+      updateTimeline();
+    });
+
+    updateToggleButton();
+    updateTimeline();
+  });
 }
 
 function renderRichTemplate(item) {
@@ -968,6 +1030,7 @@ function resetMobileMusicPopup() {
   container.appendChild(introText);
   container.appendChild(introArrow);
   container.appendChild(wrapper);
+  initializeInstrumentalPlayers(container);
 }
 
 // =============================

--- a/style.css
+++ b/style.css
@@ -768,6 +768,12 @@ body.light-mode .audio-item__play-btn {
   background: rgba(0, 0, 0, 0.45);
 }
 
+.music-template-title {
+  margin: 0;
+  font-size: 14px;
+  text-align: left;
+}
+
 .music-template-field {
   display: flex;
   flex-direction: column;
@@ -801,6 +807,60 @@ body.light-mode .audio-item__play-btn {
   width: 100%;
 }
 
+.instrumental-player {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+}
+
+.instrumental-player__button {
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  background: rgba(0, 0, 0, 0.55);
+  color: inherit;
+  cursor: pointer;
+  width: 36px;
+  height: 28px;
+  font-size: 14px;
+  line-height: 1;
+  display: grid;
+  place-items: center;
+}
+
+.instrumental-player__timeline {
+  width: 100%;
+  margin: 0;
+}
+
+.instrumental-player__timeline::-webkit-slider-runnable-track {
+  height: 4px;
+  background: rgba(255, 255, 255, 0.4);
+}
+
+.instrumental-player__timeline::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 12px;
+  height: 12px;
+  margin-top: -4px;
+  border-radius: 50%;
+  border: none;
+  background: #b56aff;
+}
+
+.instrumental-player__timeline::-moz-range-track {
+  height: 4px;
+  background: rgba(255, 255, 255, 0.4);
+}
+
+.instrumental-player__timeline::-moz-range-thumb {
+  width: 12px;
+  height: 12px;
+  border: none;
+  border-radius: 50%;
+  background: #b56aff;
+}
+
 .music-placeholder-note {
   margin: 0;
   font-size: 12px;
@@ -817,6 +877,19 @@ body.light-mode .music-template-field textarea {
   background: rgba(255, 255, 255, 0.8);
   color: #111;
   border-color: rgba(0, 0, 0, 0.45);
+}
+
+body.light-mode .instrumental-player__button {
+  border-color: rgba(0, 0, 0, 0.35);
+  background: rgba(255, 255, 255, 0.8);
+}
+
+body.light-mode .instrumental-player__timeline::-webkit-slider-runnable-track {
+  background: rgba(0, 0, 0, 0.25);
+}
+
+body.light-mode .instrumental-player__timeline::-moz-range-track {
+  background: rgba(0, 0, 0, 0.25);
 }
 
 body.light-mode .audio-item__progress {


### PR DESCRIPTION
### Motivation
- Mantener el título y la ruta del archivo de las instrumentales solo editables desde el código (no desde la interfaz web).  
- Evitar la opción de descarga directa desde la UI usando un reproductor no nativo.  
- Mostrar un control compacto con botón de play/pause a la izquierda y una línea de tiempo a la derecha, siguiendo el diseño pedido.

### Description
- Se eliminan los campos editables de título y ruta en el template de instrumentales y ahora se muestra el título leído desde `config.js` como cabecera del bloque; cambios en `script.js`.  
- Se reemplaza el `<audio controls>` nativo por un reproductor personalizado compuesto por un botón de reproducción/pausa, un `input type="range"` como línea de tiempo y un `<audio>` sin controles, con lógica JS para sincronizar estado, progreso y scrubbing; implementado en `script.js`.  
- Se añaden estilos CSS para el nuevo layout del reproductor (botón izquierdo + timeline a la derecha) y variantes de modo claro/oscuro; cambios en `style.css`.  
- Se establece un título de ejemplo (`Beat 1`) en el array `musicDropdownSections` para la instrumental existente; cambios en `config.js`.

### Testing
- Se ejecutó la comprobación de sintaxis JS con `node --check script.js` y `node --check config.js`, ambos pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3f4be81d0832b8f58250d153ed526)