### PR TITLE
Actualizar botones play/pause del desplegable de instrumentales en móvil

### DIFF
--- a/script.js
+++ b/script.js
@@ -853,7 +853,15 @@ function renderInstrumentalTemplate(item) {
   const audioMarkup = safeAssetPath
     ? `
       <div class="instrumental-player" data-instrumental-player>
-        <button type="button" class="instrumental-player__button" data-role="toggle" aria-label="Reproducir instrumental">▶</button>
+        <button type="button" class="instrumental-player__button" data-role="toggle" aria-label="Reproducir instrumental">
+          <img
+            class="instrumental-player__icon"
+            data-role="toggle-icon"
+            src="assets/play.png"
+            alt=""
+            aria-hidden="true"
+          >
+        </button>
         <input
           class="instrumental-player__timeline"
           data-role="timeline"
@@ -885,12 +893,13 @@ function initializeInstrumentalPlayers(container = document) {
   players.forEach(player => {
     const audio = player.querySelector('[data-role="audio"]');
     const toggleButton = player.querySelector('[data-role="toggle"]');
+    const toggleIcon = player.querySelector('[data-role="toggle-icon"]');
     const timeline = player.querySelector('[data-role="timeline"]');
-    if (!audio || !toggleButton || !timeline) return;
+    if (!audio || !toggleButton || !toggleIcon || !timeline) return;
 
     const updateToggleButton = () => {
       const isPlaying = !audio.paused;
-      toggleButton.textContent = isPlaying ? '❚❚' : '▶';
+      toggleIcon.src = isPlaying ? 'assets/pause.png' : 'assets/play.png';
       toggleButton.setAttribute('aria-label', isPlaying ? 'Pausar instrumental' : 'Reproducir instrumental');
     };
 

--- a/style.css
+++ b/style.css
@@ -815,16 +815,21 @@ body.light-mode .audio-item__play-btn {
 }
 
 .instrumental-player__button {
-  border: 1px solid rgba(255, 255, 255, 0.55);
-  background: rgba(0, 0, 0, 0.55);
+  border: none;
+  background: transparent;
   color: inherit;
   cursor: pointer;
   width: 36px;
   height: 28px;
-  font-size: 14px;
-  line-height: 1;
-  display: grid;
-  place-items: center;
+  padding: 0;
+  display: block;
+}
+
+.instrumental-player__icon {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: contain;
 }
 
 .instrumental-player__timeline {
@@ -877,11 +882,6 @@ body.light-mode .music-template-field textarea {
   background: rgba(255, 255, 255, 0.8);
   color: #111;
   border-color: rgba(0, 0, 0, 0.45);
-}
-
-body.light-mode .instrumental-player__button {
-  border-color: rgba(0, 0, 0, 0.35);
-  background: rgba(255, 255, 255, 0.8);
 }
 
 body.light-mode .instrumental-player__timeline::-webkit-slider-runnable-track {


### PR DESCRIPTION
### Motivation
- Cambiar la representación del botón play/pause dentro del bloque desplegable de instrumentales en la vista móvil para usar las imágenes `assets/play.png` y `assets/pause.png` en lugar de texto. 
- Mantener el mismo tamaño y funcionalidad del control y eliminar fondo/borde visual del botón para integrarlo con el diseño.

### Description
- Reemplacé el contenido textual del botón por un `<img>` en `renderInstrumentalTemplate` para mostrar inicialmente `assets/play.png`, en `script.js`.
- Actualicé `initializeInstrumentalPlayers` en `script.js` para consultar el `data-role="toggle-icon"` y alternar su `src` entre `assets/pause.png` y `assets/play.png` según el estado del audio, conservando el `aria-label` dinámico.
- Ajusté estilos en `style.css` para que `.instrumental-player__button` sea transparente y sin borde, conserve las dimensiones `36px x 28px`, y añadí `.instrumental-player__icon` con `object-fit: contain` para que la imagen ocupe el mismo espacio sin deformarse.
- Archivos modificados: `script.js` y `style.css`.

### Testing
- Ejecuté la comprobación de sintaxis con `node --check script.js`, la cual finalizó correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3f90ca3dc832b9cb0ed0b4dc7cba8)