### PR TITLE
Reduce mobile instrumental timeline end-cap size to avoid distortion

### DIFF
--- a/style.css
+++ b/style.css
@@ -1543,6 +1543,12 @@ body.light-mode .audio-item__progress {
     padding: 6px 0 12px;
   }
 
+  /* En móvil reducimos extremos de la barra para evitar deformación visual */
+  .instrumental-player__timeline {
+    --timeline-cap-width: 10px;
+    --timeline-height: 10px;
+  }
+
   .mobile-music-intro {
     margin: 10px auto 10px;
     width: 90%;


### PR DESCRIPTION
### Motivation
- The mobile instrumental timeline end caps appeared visually distorted at small sizes inside the instrumentals dropdown, so the track cap and height need to be reduced to improve rendering on mobile.

### Description
- Add a mobile-scoped CSS override setting `--timeline-cap-width: 10px` and `--timeline-height: 10px` on `.instrumental-player__timeline` inside the mobile/popup styles to reduce the extremes of the bar.
- The change is confined to the mobile popup area so desktop timeline styling is not affected.
- Slider thumb sizing and other desktop timeline assets are left unchanged.

### Testing
- Inspected the `style.css` diff to confirm the new variables are present under the mobile popup block; the check succeeded.
- Verified the file excerpt containing the new override with a line-numbered file output; the check succeeded.
- Visual/browser screenshot testing was not available in this environment, so no rendered verification was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3ffa2d28c832baf141722d69ee146)