### PR TITLE
Aplica marco 'contenedor web' a las cards de instrumentales

### DIFF
--- a/style.css
+++ b/style.css
@@ -768,6 +768,15 @@ body.light-mode .audio-item__play-btn {
   background: rgba(0, 0, 0, 0.45);
 }
 
+.music-template-card--audio {
+  border: 32px solid transparent;
+  border-image-source: url("assets/contenedor web.png");
+  border-image-slice: 32 fill;
+  border-image-repeat: stretch;
+  background: transparent;
+  padding: 8px 10px 10px;
+}
+
 .music-template-title {
   margin: 0;
   font-size: 14px;
@@ -898,6 +907,11 @@ body.light-mode .audio-item__play-btn {
 body.light-mode .music-template-card {
   background: rgba(255, 255, 255, 0.55);
   border-color: rgba(0, 0, 0, 0.25);
+}
+
+body.light-mode .music-template-card--audio {
+  background: transparent;
+  border-color: transparent;
 }
 
 body.light-mode .music-template-field input,


### PR DESCRIPTION
### Motivation
- Aplicar la misma técnica de 9-slice usada en otros desplegables de la sección de música para que el desplegable de `Instrumentales` use la imagen `assets/contenedor web.png` como marco escalable y mantenga las esquinas, bordes y centro al redimensionarse.

### Description
- Añadí la regla CSS `.music-template-card--audio` que usa `border-image-source: url("assets/contenedor web.png")`, `border-image-slice: 32 fill`, `border-image-repeat: stretch`, y ajusta `padding` y `background` para integrar el marco; además añadí `body.light-mode .music-template-card--audio` para mantener el fondo transparente en modo claro. 

### Testing
- Ejecuté comprobaciones de control de cambios con `git status --short` y `git diff -- style.css` y confirmé el commit con `git commit -m "Aplicar contenedor web al desplegable de instrumentales"`, todos los comandos finalizaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d401818f10832ba62f83698c7bb1a9)