### PR TITLE
Aumenta el tamaño del control dot en la timeline de instrumentales

### DIFF
--- a/style.css
+++ b/style.css
@@ -844,6 +844,7 @@ body.light-mode .audio-item__play-btn {
 .instrumental-player__timeline {
   --timeline-cap-width: 14px;
   --timeline-height: 12px;
+  --timeline-thumb-size: 18px;
   width: 100%;
   margin: 0;
   height: var(--timeline-height);
@@ -867,9 +868,9 @@ body.light-mode .audio-item__play-btn {
 .instrumental-player__timeline::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
-  width: 14px;
-  height: 14px;
-  margin-top: calc((var(--timeline-height) - 14px) / 2);
+  width: var(--timeline-thumb-size);
+  height: var(--timeline-thumb-size);
+  margin-top: calc((var(--timeline-height) - var(--timeline-thumb-size)) / 2);
   border: none;
   background: url("assets/dot.png") center / contain no-repeat;
 }
@@ -892,8 +893,8 @@ body.light-mode .audio-item__play-btn {
 }
 
 .instrumental-player__timeline::-moz-range-thumb {
-  width: 14px;
-  height: 14px;
+  width: var(--timeline-thumb-size);
+  height: var(--timeline-thumb-size);
   border: none;
   background: url("assets/dot.png") center / contain no-repeat;
 }
@@ -1561,6 +1562,7 @@ body.light-mode .audio-item__progress {
   .instrumental-player__timeline {
     --timeline-cap-width: 10px;
     --timeline-height: 10px;
+    --timeline-thumb-size: 16px;
   }
 
   .mobile-music-intro {


### PR DESCRIPTION
### Motivation
- El punto indicador (`assets/dot.png`) de la línea de tiempo del reproductor de instrumentales era pequeño y necesitaba mayor visibilidad sin romper el diseño en móvil.

### Description
- Se añadió la variable CSS `--timeline-thumb-size` en `.instrumental-player__timeline` y se estableció a `18px` para escritorio.
- El thumb de WebKit (`::-webkit-slider-thumb`) ahora usa `--timeline-thumb-size` para `width`, `height` y `margin-top` para mantener el centrado vertical.
- El thumb de Firefox (`::-moz-range-thumb`) también usa `--timeline-thumb-size` para consistencia entre navegadores.
- En la regla móvil se ajustó `--timeline-thumb-size` a `16px` para mantener proporciones en pantallas pequeñas.

### Testing
- Ejecuté `git diff -- style.css` para revisar los cambios de CSS y la salida fue la esperada (diff muestra las sustituciones por la variable).
- Ejecuté `git status --short` para confirmar el archivo modificado y el commit se creó correctamente con el mensaje indicado.
- El cambio quedó commiteado y se creó el PR con este título.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d403c52270832baa742980f56e4d67)