### PR TITLE
Add 'cover' music template with renderer, config entry, and styles

### DIFF
--- a/config.js
+++ b/config.js
@@ -96,15 +96,18 @@ export const musicDropdownSections = [
     title: 'Covers',
     frameImage: 'assets/contenedor música cov.png',
     template: {
-      type: 'rich'
+      type: 'cover'
     },
     items: [
       {
-        title: '',
-        text: '',
-        imagePath: '',
+        title: 'Cover · Ode to the Mets',
+        text: 'Versión en directo con una interpretación más íntima y una mezcla atmosférica.',
+        images: [
+          'assets/MINI 7.jpg',
+          'assets/MINI 8.jpg'
+        ],
         audioPath: '',
-        url: ''
+        url: 'https://www.youtube.com/watch?v=Ty9qdc1WhfI'
       }
     ]
   }

--- a/script.js
+++ b/script.js
@@ -969,6 +969,72 @@ function renderRichTemplate(item) {
   `;
 }
 
+function renderCoverTemplate(item) {
+  const safeTitle = item.title || 'Cover sin título';
+  const safeText = item.text || '';
+  const images = Array.isArray(item.images)
+    ? item.images.filter(Boolean)
+    : (item.imagePath ? [item.imagePath] : []);
+  const safeAudioPath = item.audioPath || '';
+  const safeUrl = item.url || '';
+
+  return `
+    <article class="music-template-card music-template-card--cover">
+      <h4 class="music-template-title">${safeTitle}</h4>
+      ${safeText ? `<p class="music-cover-description">${safeText}</p>` : ''}
+      ${
+        images.length
+          ? `<div class="music-cover-carousel">
+              ${images.map((imagePath, index) => `
+                <img
+                  class="music-cover-carousel__image"
+                  src="${imagePath}"
+                  alt="${safeTitle} - imagen ${index + 1}"
+                >
+              `).join('')}
+            </div>`
+          : '<p class="music-cover-note">No hay imágenes disponibles por ahora.</p>'
+      }
+      ${
+        safeAudioPath
+          ? `
+            <div class="music-template-player">
+              <div class="instrumental-player" data-instrumental-player>
+                <button
+                  class="instrumental-player__button"
+                  type="button"
+                  data-role="toggle"
+                  aria-label="Reproducir cover"
+                >
+                  <img
+                    class="instrumental-player__icon"
+                    data-role="toggle-icon"
+                    src="assets/play.png"
+                    alt=""
+                    aria-hidden="true"
+                  >
+                </button>
+                <input
+                  class="instrumental-player__timeline"
+                  data-role="timeline"
+                  type="range"
+                  min="0"
+                  max="100"
+                  step="0.1"
+                  value="0"
+                  aria-label="Línea de tiempo del cover"
+                >
+                <audio preload="metadata" src="${safeAudioPath}" data-role="audio"></audio>
+              </div>
+            </div>
+          `
+          : '<p class="music-cover-note">Audio no disponible.</p>'
+      }
+      ${safeUrl ? `<a class="music-cover-link" href="${safeUrl}" target="_blank" rel="noopener">Ver vídeo</a>` : '<p class="music-cover-note">Vídeo no disponible.</p>'}
+    </article>
+  `;
+}
+
 function renderMusicSectionContent(section) {
   if (!section.items || section.items.length === 0) {
     return '<p class="mobile-music-dropdown__placeholder">Próximamente…</p>';
@@ -980,6 +1046,10 @@ function renderMusicSectionContent(section) {
 
   if (section.template?.type === 'rich') {
     return section.items.map(renderRichTemplate).join('');
+  }
+
+  if (section.template?.type === 'cover') {
+    return section.items.map(renderCoverTemplate).join('');
   }
 
   return section.items

--- a/style.css
+++ b/style.css
@@ -783,6 +783,47 @@ body.light-mode .audio-item__play-btn {
   text-align: left;
 }
 
+.music-cover-description {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.music-cover-link {
+  display: inline-flex;
+  align-self: flex-start;
+  padding: 6px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  border-radius: 999px;
+  color: inherit;
+  text-decoration: none;
+  font-size: 12px;
+}
+
+.music-cover-note {
+  margin: 0;
+  font-size: 12px;
+  opacity: 0.85;
+}
+
+.music-cover-carousel {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(140px, 80%);
+  gap: 8px;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  padding-bottom: 4px;
+}
+
+.music-cover-carousel__image {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-radius: 8px;
+  scroll-snap-align: start;
+}
+
 .music-template-field {
   display: flex;
   flex-direction: column;
@@ -913,6 +954,10 @@ body.light-mode .music-template-card {
 body.light-mode .music-template-card--audio {
   background: transparent;
   border-color: transparent;
+}
+
+body.light-mode .music-cover-link {
+  border-color: rgba(0, 0, 0, 0.45);
 }
 
 body.light-mode .music-template-field input,


### PR DESCRIPTION
### Motivation
- Introduce a dedicated "cover" template type to better present cover tracks with multiple images, a description, audio player, and external video link.

### Description
- Add a `cover` template entry to `musicDropdownSections` in `config.js` and populate the sample item with `title`, `text`, `images`, and `url` fields.
- Implement `renderCoverTemplate` in `script.js` to render title, description, optional image carousel, an audio player when available, and a video link, with sensible fallbacks for missing data.
- Wire the new renderer into `renderMusicSectionContent` so sections with `template.type === 'cover'` use the new template, while preserving existing `audio` and `rich` handlers.
- Add CSS rules in `style.css` to style the cover card, image carousel, notes, and link, including light-mode adjustments.

### Testing
- Ran the existing test suite with `npm test` and it completed successfully. 
- Ran the linter with `npm run lint` and it reported no new issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d426abd640832bae97ab32b3feed71)