### PR TITLE
Add click-to-zoom behavior for music cover carousel images

### DIFF
--- a/script.js
+++ b/script.js
@@ -1035,6 +1035,25 @@ function renderCoverTemplate(item) {
   `;
 }
 
+function initializeCoverImageZoom(container = document) {
+  const images = container.querySelectorAll('.music-cover-carousel__image');
+  images.forEach(image => {
+    if (image.dataset.zoomEnabled === 'true') return;
+    image.dataset.zoomEnabled = 'true';
+    image.addEventListener('click', () => {
+      const carousel = image.closest('.music-cover-carousel');
+      if (!carousel) return;
+      const alreadyEnlarged = image.classList.contains('is-enlarged');
+      carousel.querySelectorAll('.music-cover-carousel__image.is-enlarged').forEach(img => {
+        img.classList.remove('is-enlarged');
+      });
+      if (!alreadyEnlarged) {
+        image.classList.add('is-enlarged');
+      }
+    });
+  });
+}
+
 function renderMusicSectionContent(section) {
   if (!section.items || section.items.length === 0) {
     return '<p class="mobile-music-dropdown__placeholder">Próximamente…</p>';
@@ -1110,6 +1129,7 @@ function resetMobileMusicPopup() {
   container.appendChild(introArrow);
   container.appendChild(wrapper);
   initializeInstrumentalPlayers(container);
+  initializeCoverImageZoom(container);
 }
 
 // =============================

--- a/style.css
+++ b/style.css
@@ -822,6 +822,16 @@ body.light-mode .audio-item__play-btn {
   object-fit: cover;
   border-radius: 8px;
   scroll-snap-align: start;
+  cursor: zoom-in;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.music-cover-carousel__image.is-enlarged {
+  transform: scale(1.6);
+  transform-origin: center center;
+  z-index: 1;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
+  cursor: zoom-out;
 }
 
 .music-template-field {


### PR DESCRIPTION
### Motivation
- Allow users to enlarge cover images in the music cover carousel for a better preview without changing the DOM structure of the carousel.

### Description
- Add `initializeCoverImageZoom` to `script.js` to attach a click handler that toggles an `is-enlarged` class on `.music-cover-carousel__image` elements and prevent duplicate listeners, and call it from `resetMobileMusicPopup`; update `style.css` with transitions, cursor hints, and `.is-enlarged` styles to scale and shadow the image.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d42a3dc980832bb3a10814bbe99db6)