### PR TITLE
Fix cover carousel image zoom overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -812,8 +812,9 @@ body.light-mode .audio-item__play-btn {
   grid-auto-columns: minmax(140px, 80%);
   gap: 8px;
   overflow-x: auto;
+  overflow-y: visible;
   scroll-snap-type: x mandatory;
-  padding-bottom: 4px;
+  padding: 18px 0;
 }
 
 .music-cover-carousel__image {
@@ -827,9 +828,10 @@ body.light-mode .audio-item__play-btn {
 }
 
 .music-cover-carousel__image.is-enlarged {
+  position: relative;
   transform: scale(1.6);
   transform-origin: center center;
-  z-index: 1;
+  z-index: 4;
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
   cursor: zoom-out;
 }


### PR DESCRIPTION
### Motivation
- Prevent cover images from being visually clipped when zoomed so enlarged previews can stand out from the carousel lane.

### Description
- Modify `style.css` to set `.music-cover-carousel` to `overflow-y: visible` and `padding: 18px 0`, and update `.music-cover-carousel__image.is-enlarged` to `position: relative` with `z-index: 4` so enlarged images can overflow and layer above nearby content.

### Testing
- Ran the automated `python` replacement script that validates and applies the CSS changes and confirmed the new rules are present in `style.css`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d42c7ab628832b9cb6b48b13dc794e)