### PR TITLE
Ajustar carrusel de covers para permitir overflow vertical, añadir padding y mejorar z-index

### DIFF
--- a/style.css
+++ b/style.css
@@ -812,8 +812,9 @@ body.light-mode .audio-item__play-btn {
   grid-auto-columns: minmax(140px, 80%);
   gap: 8px;
   overflow-x: auto;
+  overflow-y: visible;
   scroll-snap-type: x mandatory;
-  padding-bottom: 4px;
+  padding: 18px 0;
 }
 
 .music-cover-carousel__image {
@@ -829,7 +830,8 @@ body.light-mode .audio-item__play-btn {
 .music-cover-carousel__image.is-enlarged {
   transform: scale(1.6);
   transform-origin: center center;
-  z-index: 1;
+  position: relative;
+  z-index: 4;
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
   cursor: zoom-out;
 }


### PR DESCRIPTION
### Motivation
- Mejorar la experiencia al ampliar imágenes en el carrusel de covers para que las imágenes ampliadas puedan sobresalir verticalmente, tengan espacio visual y queden por encima de elementos cercanos.

### Description
- Actualiza `.music-cover-carousel` para usar `overflow-y: visible` y `padding: 18px 0` para permitir el desbordamiento vertical y dar margen visual a las imágenes ampliadas.
- Añade `position: relative` y `z-index: 4` a `.music-cover-carousel__image.is-enlarged` para asegurar que la imagen ampliada se apile sobre elementos adyacentes.
- Los cambios se aplicaron en el archivo `style.css`.

### Testing
- Se validó el diff de CSS mostrando las propiedades añadidas y modificadas en `style.css`.
- No se ejecutaron pruebas automatizadas específicas para este cambio de estilo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d42d487704832b99b9ee0e2e0af038)