### PR TITLE
Abrir imágenes de covers en lightbox fullscreen al hacer clic

### DIFF
--- a/script.js
+++ b/script.js
@@ -1041,18 +1041,64 @@ function initializeCoverImageZoom(container = document) {
     if (image.dataset.zoomEnabled === 'true') return;
     image.dataset.zoomEnabled = 'true';
     image.addEventListener('click', () => {
-      const carousel = image.closest('.music-cover-carousel');
-      if (!carousel) return;
-      const alreadyEnlarged = image.classList.contains('is-enlarged');
-      carousel.querySelectorAll('.music-cover-carousel__image.is-enlarged').forEach(img => {
-        img.classList.remove('is-enlarged');
-      });
-      if (!alreadyEnlarged) {
-        image.classList.add('is-enlarged');
-      }
+      openCoverImageLightbox(image);
     });
   });
 }
+
+function getCoverImageLightbox() {
+  let lightbox = document.querySelector('[data-cover-lightbox]');
+  if (lightbox) return lightbox;
+
+  lightbox = document.createElement('div');
+  lightbox.className = 'music-cover-lightbox';
+  lightbox.dataset.coverLightbox = 'true';
+  lightbox.setAttribute('aria-hidden', 'true');
+
+  lightbox.innerHTML = `
+    <button type="button" class="music-cover-lightbox__close" aria-label="Cerrar imagen">×</button>
+    <img class="music-cover-lightbox__image" src="" alt="">
+  `;
+
+  const closeButton = lightbox.querySelector('.music-cover-lightbox__close');
+  closeButton?.addEventListener('click', closeCoverImageLightbox);
+
+  lightbox.addEventListener('click', event => {
+    if (event.target === lightbox) {
+      closeCoverImageLightbox();
+    }
+  });
+
+  document.body.appendChild(lightbox);
+  return lightbox;
+}
+
+function openCoverImageLightbox(sourceImage) {
+  if (!sourceImage) return;
+  const lightbox = getCoverImageLightbox();
+  const lightboxImage = lightbox.querySelector('.music-cover-lightbox__image');
+  if (!lightboxImage) return;
+
+  lightboxImage.src = sourceImage.currentSrc || sourceImage.src;
+  lightboxImage.alt = sourceImage.alt || 'Imagen de cover';
+  lightbox.classList.add('is-open');
+  lightbox.setAttribute('aria-hidden', 'false');
+  document.body.classList.add('is-cover-lightbox-open');
+}
+
+function closeCoverImageLightbox() {
+  const lightbox = document.querySelector('[data-cover-lightbox]');
+  if (!lightbox) return;
+  lightbox.classList.remove('is-open');
+  lightbox.setAttribute('aria-hidden', 'true');
+  document.body.classList.remove('is-cover-lightbox-open');
+}
+
+document.addEventListener('keydown', event => {
+  if (event.key === 'Escape') {
+    closeCoverImageLightbox();
+  }
+});
 
 function renderMusicSectionContent(section) {
   if (!section.items || section.items.length === 0) {

--- a/style.css
+++ b/style.css
@@ -824,16 +824,52 @@ body.light-mode .audio-item__play-btn {
   border-radius: 8px;
   scroll-snap-align: start;
   cursor: zoom-in;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: box-shadow 0.2s ease;
 }
 
-.music-cover-carousel__image.is-enlarged {
-  transform: scale(1.6);
-  transform-origin: center center;
-  position: relative;
-  z-index: 4;
+.music-cover-carousel__image:active {
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
-  cursor: zoom-out;
+}
+
+.music-cover-lightbox {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 24px 0;
+  background: rgba(0, 0, 0, 0.82);
+  z-index: 1200;
+}
+
+.music-cover-lightbox.is-open {
+  display: flex;
+}
+
+.music-cover-lightbox__image {
+  width: 100vw;
+  max-width: 100vw;
+  max-height: 85vh;
+  object-fit: contain;
+}
+
+.music-cover-lightbox__close {
+  position: absolute;
+  top: 12px;
+  right: 14px;
+  border: 0;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  font-size: 28px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+body.is-cover-lightbox-open {
+  overflow: hidden;
 }
 
 .music-template-field {


### PR DESCRIPTION
### Motivation
- Evitar que las imágenes del carrusel de covers solo se agranden dentro del layout y, en su lugar, mostrarlas ocupando el ancho de la pantalla para mejor visualización.

### Description
- Reemplacé el toggle de clase `.is-enlarged` por un lightbox reutilizable que muestra la imagen seleccionada en un overlay fullscreen; funciones añadidas: `getCoverImageLightbox`, `openCoverImageLightbox`, `closeCoverImageLightbox` y manejo de `Escape` para cerrar. (`script.js`)
- Añadí estilos para el modal fullscreen, la imagen a `100vw`, el botón de cierre y bloqueo de scroll del `body` mientras el lightbox está abierto. (`style.css`)
- Eliminé el comportamiento de `transform: scale(...)` que aumentaba la imagen dentro del carrusel y ajusté la transición para evitar efectos de escalado en sitio. (`style.css`)
- `initializeCoverImageZoom` ahora abre el lightbox al hacer clic en cualquier `.music-cover-carousel__image`. (`script.js`)

### Testing
- Ejecuté `node --check script.js` y la verificación de sintaxis JavaScript pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d433149564832b8f68f07175b9d00f)