### PR TITLE
Add chevron indicator and open-state rotation to mobile music dropdowns

### DIFF
--- a/style.css
+++ b/style.css
@@ -1724,6 +1724,20 @@ body.light-mode .audio-item__progress {
     color: #fff;
     box-sizing: border-box;
     overflow: hidden;
+    position: relative;
+  }
+
+  .mobile-music-dropdown::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    right: 15px;
+    width: 18px;
+    height: 18px;
+    transform: translateY(-50%);
+    background: url('assets/desp.png') center / contain no-repeat;
+    pointer-events: none;
+    opacity: 0.95;
   }
 
   .mobile-music-dropdown__summary {
@@ -1738,6 +1752,10 @@ body.light-mode .audio-item__progress {
     letter-spacing: 0.02em;
     font-size: 16px;
     text-align: left;
+  }
+
+  .mobile-music-dropdown[open]::after {
+    transform: translateY(-50%) rotate(180deg);
   }
 
   .mobile-music-dropdown__summary::marker,


### PR DESCRIPTION
### Motivation
- Improve affordance for mobile music dropdowns by adding a visible chevron/arrow indicator and visual feedback when the dropdown is opened.

### Description
- Updated `style.css` to set `.mobile-music-dropdown` to `position: relative` to anchor a pseudo-element.
- Added a `::after` pseudo-element on `.mobile-music-dropdown` that displays `assets/desp.png` as a chevron at the right side and disables pointer events.
- Added an open-state rule `.mobile-music-dropdown[open]::after` to rotate the chevron `180deg` when the dropdown is expanded.

### Testing
- No automated tests were executed for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4da9ee208832bbea994ef716fb0e7)