### PR TITLE
Per-section cover frame images and cover template updates

### DIFF
--- a/config.js
+++ b/config.js
@@ -78,16 +78,18 @@ export const musicDropdownSections = [
     id: 'experimentos',
     title: 'Experimentos',
     frameImage: 'assets/contenedor música exp.png',
+    cardFrameImage: 'assets/contenedor covers.png',
     template: {
-      type: 'rich'
+      type: 'cover'
     },
     items: [
       {
         title: '',
         text: '',
-        imagePath: '',
-        audioPath: '',
-        url: ''
+        images: [
+          ''
+        ],
+        audioPath: ''
       }
     ]
   },
@@ -95,6 +97,7 @@ export const musicDropdownSections = [
     id: 'covers',
     title: 'Covers',
     frameImage: 'assets/contenedor música cov.png',
+    cardFrameImage: 'assets/contenedor covers.png',
     template: {
       type: 'cover'
     },

--- a/script.js
+++ b/script.js
@@ -969,7 +969,7 @@ function renderRichTemplate(item) {
   `;
 }
 
-function renderCoverTemplate(item) {
+function renderCoverTemplate(item, section = {}) {
   const safeTitle = item.title || 'Cover sin título';
   const safeText = item.text || '';
   const images = Array.isArray(item.images)
@@ -977,9 +977,10 @@ function renderCoverTemplate(item) {
     : (item.imagePath ? [item.imagePath] : []);
   const safeAudioPath = item.audioPath || '';
   const safeUrl = item.url || '';
+  const cardFrameImage = section.cardFrameImage || 'assets/contenedor covers.png';
 
   return `
-    <article class="music-template-card music-template-card--cover">
+    <article class="music-template-card music-template-card--cover" style="--music-cover-frame-image: url('${cardFrameImage}')">
       <h4 class="music-template-title">${safeTitle}</h4>
       ${safeText ? `<p class="music-cover-description">${safeText}</p>` : ''}
       ${
@@ -1114,7 +1115,7 @@ function renderMusicSectionContent(section) {
   }
 
   if (section.template?.type === 'cover') {
-    return section.items.map(renderCoverTemplate).join('');
+    return section.items.map(item => renderCoverTemplate(item, section)).join('');
   }
 
   return section.items

--- a/style.css
+++ b/style.css
@@ -779,7 +779,7 @@ body.light-mode .audio-item__play-btn {
 
 .music-template-card--cover {
   border: 32px solid transparent;
-  border-image-source: url("assets/contenedor covers.png");
+  border-image-source: var(--music-cover-frame-image, url("assets/contenedor covers.png"));
   border-image-slice: 32 fill;
   border-image-repeat: stretch;
   background: transparent;


### PR DESCRIPTION
### Motivation

- Allow each music section to supply a custom frame image for cover cards so covers can use section-specific borders.
- Normalize the `experimentos` section items to the same `cover` template shape used by `covers` for consistent rendering.

### Description

- Add `cardFrameImage` to `musicDropdownSections` for `experimentos` and `covers` and change `experimentos.template.type` from `rich` to `cover` while adapting its item shape to use `images` and `audioPath` fields. 
- Change `renderCoverTemplate` signature to accept a `section` argument and read `section.cardFrameImage` to set an inline CSS variable `--music-cover-frame-image` on the cover card. 
- Update `renderMusicSectionContent` to pass the `section` into `renderCoverTemplate` when rendering `cover` templates. 
- Make the `.music-template-card--cover` CSS use `border-image-source: var(--music-cover-frame-image, url("assets/contenedor covers.png"))` so the border image becomes dynamic with a sensible default. 

### Testing

- Ran linting with `npm run lint` and it completed successfully. 
- Built the project with `npm run build` and the build succeeded. 
- Executed the test suite with `npm test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4dde7c2c4832babe020052ecc8d62)