### PR TITLE
Simplificar layout de escritorio: centrar UI y escalar a ~20% (CSS)

### DIFF
--- a/style.css
+++ b/style.css
@@ -1579,6 +1579,92 @@ body.light-mode .audio-item__progress {
     display: block;
   }
 
+  @media (min-width: 1024px) and (pointer: fine) {
+    #mobile-intro-typing {
+      max-width: 18vw;
+      font-size: clamp(10px, 0.9vw, 16px);
+      line-height: 1.45;
+    }
+
+    #mobile-featured-social-buttons {
+      width: 18vw;
+      gap: 0.8vw;
+    }
+
+    #mobile-youtube-btn,
+    #mobile-instagram-btn,
+    #mobile-tiktok-btn,
+    #mobile-contact-btn {
+      width: 4vw;
+      max-width: 84px;
+      min-width: 44px;
+    }
+
+    .mobile-hero-carousel {
+      width: 20vw;
+      top: 53%;
+    }
+
+    .mobile-carousel-track {
+      width: 20vw;
+      overflow-x: auto;
+      scroll-snap-type: x mandatory;
+      -webkit-overflow-scrolling: touch;
+    }
+
+    .mobile-carousel-slide {
+      flex: 0 0 18vw;
+      width: 18vw;
+      max-width: 18vw;
+      scroll-snap-align: center;
+      scroll-snap-stop: always;
+    }
+
+    #mobile-intro-arrow {
+      width: clamp(22px, 2.8vw, 48px);
+    }
+
+    #mobile-menu {
+      align-items: center;
+      gap: clamp(8px, 1.2vh, 14px);
+      padding-bottom: 4vh;
+    }
+
+    .mobile-item {
+      width: 20vw;
+      max-width: 20vw;
+      min-width: 220px;
+    }
+
+    .mobile-item-label {
+      font-size: clamp(14px, 1.3vw, 22px);
+    }
+
+    #mobile-final-text {
+      width: 18vw;
+      font-size: clamp(10px, 0.95vw, 14px);
+      line-height: 1.8;
+    }
+
+    #mobile-restart-btn {
+      width: 8vw;
+      max-width: 120px;
+      min-width: 56px;
+    }
+
+    #mobile-final-social-buttons {
+      width: 14vw;
+      right: 50%;
+      transform: translateX(50%);
+      justify-content: center;
+      gap: 0.9vw;
+    }
+
+    #mobile-final-social-buttons a {
+      width: clamp(20px, 2vw, 34px);
+    }
+  }
+
   @keyframes mobile-type-line {
     from {
       width: 0;


### PR DESCRIPTION
### Motivation
- Crear una versión de escritorio muy simple que replique la lógica visual móvil pero centrando todos los elementos y limitando su ancho al entorno del 20% de la pantalla.
- Asegurar que los botones que abren las ventanas emergentes ocupen exactamente el 20% del ancho y que el resto de elementos sean ligeramente más estrechos, manteniendo el carrusel de "últimos trabajos" con overflow horizontal y la imagen central algo menor que los botones.
- Permitir una previsualización rápida para validar la nueva lógica sin cambiar la lógica JavaScript existente.

### Description
- Añadida una media query en `style.css` (`@media (min-width: 1024px) and (pointer: fine)`) que aplica el diseño de escritorio centrado y escalado alrededor del 20% del ancho de pantalla.
- Ajustados tamaños clave: las secciones/botones que abren popups (`.mobile-item`) se fijan a `20vw`, mientras que elementos auxiliares como slides del carrusel quedarán en `18vw` y otros elementos en rangos menores para respetar la jerarquía visual.
- Modificados selectores relacionados con el carrusel (`.mobile-hero-carousel`, `.mobile-carousel-track`, `.mobile-carousel-slide`) y con botones/sociales para mantener `overflow-x` del carrusel y asegurar que la imagen central sea ligeramente más pequeña que los botones.
- Cambios enteramente CSS en `style.css` sin tocar JavaScript ni comportamiento funcional.

### Testing
- Arranqué un servidor local de pruebas con `python3 -m http.server 4173` y comprobé automáticamente que `curl -I http://127.0.0.1:4173/index.html` devolviera `HTTP/1.0 200 OK`, confirmando que la vista previa sirve los archivos.
- Verifiqué que el archivo modificado `style.css` se sirve en la preview y contiene la nueva media query y reglas aplicadas correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4ec0fa4e8832b9ed9c42e0159817a)