### PR TITLE
Centrar slider "últimos trabajos" en escritorio y unificar fondo a `fondocarga.png`

### DIFF
--- a/config.js
+++ b/config.js
@@ -2,8 +2,8 @@
 
 // Imágenes de fondo para cada modo de color
 export const backgrounds = {
-  dark: 'assets/fondomed.png',
-  light: 'assets/fondomed.png'
+  dark: 'assets/fondocarga.png',
+  light: 'assets/fondocarga.png'
 };
 
 // URL del canal de YouTube (úsala para el botón destacado en móvil)

--- a/style.css
+++ b/style.css
@@ -45,8 +45,8 @@
 
 /* Variables para cambiar fácilmente las imágenes de fondo */
 :root {
-  --bg-dark: url('assets/fondomed.png');
-  --bg-light: url('assets/fondomed.png');
+  --bg-dark: url('assets/fondocarga.png');
+  --bg-light: url('assets/fondocarga.png');
   --popup-font-size: 12px;
   --popup-header-font-size: 24px;
   --close-btn-font-size: 16px;
@@ -1603,6 +1603,8 @@ body.light-mode .audio-item__progress {
     .mobile-hero-carousel {
       width: 20vw;
       top: 53%;
+      left: 50%;
+      transform: translate(-50%, -50%);
     }
 
     .mobile-carousel-track {
@@ -1610,6 +1612,8 @@ body.light-mode .audio-item__progress {
       overflow-x: auto;
       scroll-snap-type: x mandatory;
       -webkit-overflow-scrolling: touch;
+      justify-content: center;
+      margin: 0 auto;
     }
 
     .mobile-carousel-slide {


### PR DESCRIPTION
### Motivation
- El slider de la ventana de "últimos trabajos" en la versión de escritorio se veía desplazado hacia la izquierda y debe quedar centrado en la nueva maquetación. 
- Se desea usar una única imagen de fondo de escritorio (`assets/fondocarga.png`) para simplificar la apariencia y evitar inconsistencias entre variables y config.

### Description
- Actualicé las variables CSS en `:root` para que `--bg-dark` y `--bg-light` apunten a `assets/fondocarga.png` (archivo `style.css`).
- Reforcé el posicionamiento del contenedor del carrusel en el bloque de escritorio añadiendo `left: 50%` y `transform: translate(-50%, -50%)` para centrar la `mobile-hero-carousel` dentro de la media query de escritorio (archivo `style.css`).
- Centré el track del carrusel con `justify-content: center; margin: 0 auto;` para evitar que las slides queden alineadas a la izquierda (archivo `style.css`).
- Sincronizé la configuración dinámica de fondos en `config.js` para que `backgrounds.dark` y `backgrounds.light` usen `assets/fondocarga.png`.

### Testing
- Ejecuté comprobaciones de estado y diff con `git status --short` y `git diff -- style.css config.js`, y ambas mostraron los cambios esperados (éxito).
- Verifiqué el contenido de los ficheros con `nl -ba style.css | sed -n '40,60p'`, `nl -ba style.css | sed -n '1596,1622p'` y `nl -ba config.js | sed -n '1,14p'`, confirmando las líneas modificadas (éxito).
- Realicé el commit con `git commit -m "Fix desktop latest works slider centering and unify desktop background"`, que se completó correctamente (éxito).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4ef07c120832b8ce241dde4ceccf2)