### PR TITLE
Desactivar animación inicial del carrusel de "últimos trabajos" en escritorio

### DIFF
--- a/script.js
+++ b/script.js
@@ -487,6 +487,7 @@ if (mobileIntroArrow && mobileSectionsBlock) {
 // =============================
 function initMobileHeroCarousel() {
   if (!mobileHeroCarousel || !mobileHeroTrack || !mobileLatestWorks?.length) return;
+  const isDesktopViewport = () => window.matchMedia('(min-width: 1024px)').matches;
 
   const slides = [];
   const realCount = mobileLatestWorks.length;
@@ -715,7 +716,7 @@ function initMobileHeroCarousel() {
 
   // Animación de entrada sutil para indicar que se puede deslizar (solo una vez).
   function runIntroAnimation() {
-    if (introPlayed || prefersReducedMotion.matches) return;
+    if (introPlayed || prefersReducedMotion.matches || isDesktopViewport()) return;
     introPlayed = true;
     const start = currentTranslate;
     const hintOffset = -slideWidth * 0.12;
@@ -741,7 +742,7 @@ function initMobileHeroCarousel() {
   }
 
   function scheduleIntroAnimation() {
-    if (introPlayed || prefersReducedMotion.matches) return;
+    if (introPlayed || prefersReducedMotion.matches || isDesktopViewport()) return;
     introTimerId = window.setTimeout(runIntroAnimation, 1500);
   }
 


### PR DESCRIPTION
### Motivation
- Evitar que la animación de entrada del carrusel ('hint' que indica que se puede deslizar) se ejecute en la versión de escritorio porque podría estar causando problemas en ese entorno.

### Description
- Añadido un guard `isDesktopViewport` usando `window.matchMedia('(min-width: 1024px)')` dentro de `initMobileHeroCarousel` en `script.js`.
- Evitada la ejecución de la animación de entrada comprobando `isDesktopViewport()` en `runIntroAnimation` y en `scheduleIntroAnimation` para que la animación sólo se reproduzca en móviles.
- El cambio está limitado a la lógica de animación de entrada del carrusel móvil y no modifica el comportamiento del arrastre, inercia o snap.

### Testing
- No existe una suite de pruebas automatizada en este repositorio; se ejecutaron comprobaciones de control de versiones con `git status`, `git commit` y `git show --stat` y el commit se aplicó correctamente.
- Verificación manual del alcance del cambio en `script.js` sin errores de sintaxis reportados por el entorno de commits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d505aa070c832ba9d8a9839c5ce3e5)