### PR TITLE
Fix desktop latest-works carousel slide width calculation

### DIFF
--- a/script.js
+++ b/script.js
@@ -518,7 +518,16 @@ function initMobileHeroCarousel() {
     }
   });
 
-  let slideWidth = mobileHeroCarousel.getBoundingClientRect().width || window.innerWidth;
+  function resolveSlideWidth() {
+    const firstSlide = slides[0];
+    if (firstSlide) {
+      const measuredWidth = firstSlide.getBoundingClientRect().width;
+      if (measuredWidth > 0) return measuredWidth;
+    }
+    return mobileHeroCarousel.getBoundingClientRect().width || window.innerWidth;
+  }
+
+  let slideWidth = resolveSlideWidth();
   let currentIndex = 1;
   let currentTranslate = -slideWidth * currentIndex;
   let startTranslate = currentTranslate;
@@ -710,7 +719,7 @@ function initMobileHeroCarousel() {
   }
 
   function updateSizes() {
-    slideWidth = mobileHeroCarousel.getBoundingClientRect().width || window.innerWidth;
+    slideWidth = resolveSlideWidth();
     setTranslate(-currentIndex * slideWidth);
   }
 


### PR DESCRIPTION
### Motivation
- El carrusel de "últimos trabajos" se veía desplazado en la versión de escritorio porque el cálculo de traducción/snap en JS usaba el ancho del contenedor mientras que en CSS cada slide tiene un ancho distinto (`.mobile-hero-carousel` = `20vw`, `.mobile-carousel-slide` = `18vw`).
- Se buscó asegurar que la lógica de posicionamiento use el ancho real renderizado de cada slide para eliminar el desfase visual al hacer snap/loop.

### Description
- Se añadió la función `resolveSlideWidth()` en `script.js` que mide el ancho real del primer slide con `getBoundingClientRect()` y lo devuelve si es válido.  
- Reemplacé la inicialización directa de `slideWidth` y la actualización en `updateSizes()` para usar `resolveSlideWidth()` tanto al iniciar el carrusel como al redimensionar la ventana, evitando desalineaciones al hacer `snap` entre slides.

### Testing
- Ejecuté la comprobación de sintaxis con `node --check script.js` y pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5070952c4832b997eade7390d86ed)