### PR TITLE
Eliminar carrusel "últimos trabajos" en versión de escritorio

### DIFF
--- a/script.js
+++ b/script.js
@@ -124,6 +124,14 @@ window.addEventListener('resize', updateVh);
 
 function updateMobileIntroArrowPosition() {
   if (!mobileIntro || !mobileIntroArrow || !mobileHeroCarousel || !mobileFeaturedSocialButtons) return;
+  const isDesktopViewport = window.matchMedia('(min-width: 1024px) and (pointer: fine)').matches;
+
+  if (isDesktopViewport) {
+    mobileFeaturedSocialButtons.style.top = '34%';
+    mobileIntroArrow.style.top = '66%';
+    return;
+  }
+
   const heroImage = mobileHeroCarousel.querySelector('img');
   if (!heroImage) return;
 

--- a/style.css
+++ b/style.css
@@ -1601,10 +1601,7 @@ body.light-mode .audio-item__progress {
     }
 
     .mobile-hero-carousel {
-      width: 20vw;
-      top: 53%;
-      left: 50%;
-      transform: translate(-50%, -50%);
+      display: none;
     }
 
     .mobile-carousel-track {


### PR DESCRIPTION
### Motivation
- Ocultar el carrusel de "últimos trabajos" en la versión de escritorio para evitar solapamientos y mantener la disposición visual del encabezado en pantallas grandes.

### Description
- Se oculta `.mobile-hero-carousel` dentro del breakpoint `@media (min-width: 1024px) and (pointer: fine)` en `style.css` y se añade una comprobación `isDesktopViewport` en la función `updateMobileIntroArrowPosition()` de `script.js` que aplica un fallback de posicionamiento (`mobileFeaturedSocialButtons.style.top = '34%'` y `mobileIntroArrow.style.top = '66%'`) cuando el carrusel está oculto.

### Testing
- Verifiqué los cambios mediante `git diff` y confirmé el commit; los comandos de control de versiones (`git add`/`git commit`) se ejecutaron correctamente y no se detectaron errores automáticos en los archivos modificados.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d508a07bec832bbcd5ad617a2f1c6a)